### PR TITLE
Replace panics with logging to improve user-experience

### DIFF
--- a/cmd/insights/list.go
+++ b/cmd/insights/list.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/xlab/treeprint"
 
@@ -36,7 +37,7 @@ var listCmd = &cobra.Command{
 		host := configurationObject.Options.Hostname
 		checks, err := insights.GetChecks(org, insightsToken, host)
 		if err != nil {
-			panic(err)
+			logrus.Fatalf("Unable to get checks from insights: %s", err)
 		}
 		tree := treeprint.New()
 		opa := tree.AddBranch("opa")
@@ -44,7 +45,7 @@ var listCmd = &cobra.Command{
 			branch := opa.AddBranch(check.Name)
 			instances, err := insights.GetInstances(org, check.Name, insightsToken, host)
 			if err != nil {
-				panic(err)
+				logrus.Fatalf("Unable to get instances from insights: %s", err)
 			}
 			for _, instance := range instances {
 				branch.AddNode(instance.AdditionalData.Name)

--- a/cmd/insights/sync.go
+++ b/cmd/insights/sync.go
@@ -42,14 +42,14 @@ var syncCmd = &cobra.Command{
 		host := configurationObject.Options.Hostname
 		results, err := opa.CompareChecks(syncDir, org, insightsToken, host, gitOps)
 		if err != nil {
-			panic(err)
+			logrus.Fatalf("Unable to compare checks - %s", err)
 		}
 		for _, instance := range results.InstanceDelete {
 			logrus.Infof("Deleting instance: %s:%s", instance.CheckName, instance.InstanceName)
 			if !dryrun {
 				err := insights.DeleteInstance(instance, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to delete instance %s:%s - %s", instance.CheckName, instance.InstanceName, err)
 				}
 			}
 		}
@@ -58,7 +58,7 @@ var syncCmd = &cobra.Command{
 			if !dryrun {
 				err := insights.DeleteCheck(check, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to delete check %s - %s", check.CheckName, err)
 				}
 			}
 		}
@@ -67,7 +67,7 @@ var syncCmd = &cobra.Command{
 			if !dryrun {
 				err := insights.PutCheck(check, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to add check %s - %s", check.CheckName, err)
 				}
 			}
 		}
@@ -76,7 +76,7 @@ var syncCmd = &cobra.Command{
 			if !dryrun {
 				err := insights.PutCheck(check, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to update check %s - %s", check.CheckName, err)
 				}
 			}
 		}
@@ -85,7 +85,7 @@ var syncCmd = &cobra.Command{
 			if !dryrun {
 				err := insights.PutInstance(instance, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to add instance %s:%s - %s", instance.CheckName, instance.InstanceName, err)
 				}
 			}
 		}
@@ -94,7 +94,7 @@ var syncCmd = &cobra.Command{
 			if !dryrun {
 				err := insights.PutInstance(instance, org, insightsToken, host)
 				if err != nil {
-					panic(err)
+					logrus.Fatalf("Unable to update instance %s:%s - %s", instance.CheckName, instance.InstanceName, err)
 				}
 			}
 		}


### PR DESCRIPTION
This change avoids showing a panic() by outputting a fatal log which
still exits (returning an exit value of 1 to the calling shell). For example, listing OPA policies using an
invalid API token now generates an error (based on the HTTP-400 API
response), without also showing panic output.