### PR TITLE
 Add Rules engine to CLI

### DIFF
--- a/cmd/insights/list.go
+++ b/cmd/insights/list.go
@@ -39,11 +39,11 @@ var listCmd = &cobra.Command{
 		tree := treeprint.New()
 		err := opa.BuildChecksTree(org, insightsToken, host, tree)
 		if err != nil {
-			logrus.Fatalf("Unable to get checks from insights for OPA: %v", err)
+			logrus.Fatalf("Unable to get OPA checks from insights: %v", err)
 		}
 		err = rules.BuildRulesTree(org, insightsToken, host, tree)
 		if err != nil {
-			logrus.Fatalf("Unable to get checks from insights for rules: %v", err)
+			logrus.Fatalf("Unable to get rules from insights: %v", err)
 		}
 		fmt.Println(tree.String())
 	},

--- a/cmd/insights/list.go
+++ b/cmd/insights/list.go
@@ -21,7 +21,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/xlab/treeprint"
 
-	"github.com/fairwindsops/insights-cli/pkg/insights"
+	"github.com/fairwindsops/insights-cli/pkg/opa"
+	"github.com/fairwindsops/insights-cli/pkg/rules"
 )
 
 func init() {
@@ -35,22 +36,14 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		org := configurationObject.Options.Organization
 		host := configurationObject.Options.Hostname
-		checks, err := insights.GetChecks(org, insightsToken, host)
-		if err != nil {
-			logrus.Fatalf("Unable to get checks from insights: %s", err)
-		}
 		tree := treeprint.New()
-		opa := tree.AddBranch("opa")
-		for _, check := range checks {
-			branch := opa.AddBranch(check.Name)
-			instances, err := insights.GetInstances(org, check.Name, insightsToken, host)
-			if err != nil {
-				logrus.Fatalf("Unable to get instances from insights: %s", err)
-			}
-			for _, instance := range instances {
-				branch.AddNode(instance.AdditionalData.Name)
-			}
-
+		err := opa.BuildChecksTree(org, insightsToken, host, tree)
+		if err != nil {
+			logrus.Fatalf("Unable to get checks from insights for OPA: %v", err)
+		}
+		err = rules.BuildRulesTree(org, insightsToken, host, tree)
+		if err != nil {
+			logrus.Fatalf("Unable to get checks from insights for rules: %v", err)
 		}
 		fmt.Println(tree.String())
 	},

--- a/cmd/insights/sync.go
+++ b/cmd/insights/sync.go
@@ -23,13 +23,13 @@ import (
 )
 
 var syncDir string
-var gitOps bool
+var fullsync bool
 var dryrun bool
 var forRules bool
 
 func init() {
 	syncCmd.PersistentFlags().StringVarP(&syncDir, "directory", "d", ".", "Directory to sync.")
-	syncCmd.PersistentFlags().BoolVarP(&gitOps, "fullsync", "", false, "Delete any checks not found in this repository.")
+	syncCmd.PersistentFlags().BoolVarP(&fullsync, "fullsync", "", false, "Delete any checks not found in this repository.")
 	syncCmd.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "Simulates a sync.")
 	syncCmd.PersistentFlags().BoolVarP(&forRules, "rules", "", false, "Sync rules. OPA checks are synced by default otherwise.")
 	policyCmd.AddCommand(syncCmd)
@@ -43,12 +43,12 @@ var syncCmd = &cobra.Command{
 		org := configurationObject.Options.Organization
 		host := configurationObject.Options.Hostname
 		if forRules {
-			err := rules.SyncRules(syncDir, org, insightsToken, host, dryrun)
+			err := rules.SyncRules(syncDir, org, insightsToken, host, fullsync, dryrun)
 			if err != nil {
 				logrus.Fatalf("Unable to sync rules: %v", err)
 			}
 		} else {
-			err := opa.SyncOPAChecks(syncDir, org, insightsToken, host, gitOps, dryrun)
+			err := opa.SyncOPAChecks(syncDir, org, insightsToken, host, fullsync, dryrun)
 			if err != nil {
 				logrus.Fatalf("Unable to sync OPA Checks: %v", err)
 			}

--- a/cmd/insights/sync.go
+++ b/cmd/insights/sync.go
@@ -17,6 +17,7 @@ package main
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"os"
 
 	"github.com/fairwindsops/insights-cli/pkg/opa"
 	"github.com/fairwindsops/insights-cli/pkg/rules"
@@ -46,14 +47,23 @@ var syncCmd = &cobra.Command{
 		host := configurationObject.Options.Hostname
 		if !forRules || forChecks {
 			opaDir := syncDir + "/checks"
-			err := opa.SyncOPAChecks(opaDir, org, insightsToken, host, fullsync, dryrun)
+			_, err := os.Stat(opaDir)
+			if os.IsNotExist(err) {
+				logrus.Fatal("Folder for OPA checks doesn't exist. All OPA checks must be in a folder wih the name checks.")
+			}
+			err = opa.SyncOPAChecks(opaDir, org, insightsToken, host, fullsync, dryrun)
 			if err != nil {
 				logrus.Fatalf("Unable to sync OPA Checks: %v", err)
 			}
+
 		}
 		if !forChecks || forRules {
 			rulesDir := syncDir + "/rules"
-			err := rules.SyncRules(rulesDir, org, insightsToken, host, fullsync, dryrun)
+			_, err := os.Stat(rulesDir)
+			if os.IsNotExist(err) {
+				logrus.Fatal("Folder for rules doesn't exist. All rules must be in a folder wih the name rules.")
+			}
+			err = rules.SyncRules(rulesDir, org, insightsToken, host, fullsync, dryrun)
 			if err != nil {
 				logrus.Fatalf("Unable to sync rules: %v", err)
 			}

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -251,6 +251,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 	return checks, nil
 }
 
+// BuildChecksTree builds the tree for OPA checks
 func BuildChecksTree(org, token, hostName string, tree treeprint.Tree) error {
 	checks, err := GetChecks(org, token, hostName)
 	if err != nil {

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -44,7 +44,7 @@ type CompareResults struct {
 }
 
 // CompareChecks compares a folder vs the checks returned by the API.
-func CompareChecks(folder, org, token, hostName string, gitops bool) (CompareResults, error) {
+func CompareChecks(folder, org, token, hostName string, fullsync bool) (CompareResults, error) {
 	var results CompareResults
 	files, err := directory.ScanFolder(folder)
 	if err != nil {
@@ -62,7 +62,7 @@ func CompareChecks(folder, org, token, hostName string, gitops bool) (CompareRes
 		logrus.Error("Error getting checks from Insights")
 		return results, err
 	}
-	if !gitops {
+	if !fullsync {
 		apiChecks = funk.Filter(apiChecks, func(c opa.OPACustomCheck) bool {
 			return len(funk.Filter(fileChecks, func(fc models.CustomCheckModel) bool {
 				return fc.CheckName == c.Name

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -254,6 +254,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 func BuildChecksTree(org, token, hostName string, tree treeprint.Tree) error {
 	checks, err := GetChecks(org, token, hostName)
 	if err != nil {
+		logrus.Errorf("Unable to get checks from insights: %v", err)
 		return err
 	}
 	opaBranch := tree.AddBranch("opa")
@@ -261,7 +262,8 @@ func BuildChecksTree(org, token, hostName string, tree treeprint.Tree) error {
 		branch := opaBranch.AddBranch(check.Name)
 		instances, err := GetInstances(org, check.Name, token, hostName)
 		if err != nil {
-			return nil
+			logrus.Errorf("Unable to get instances from insights: %v", err)
+			return err
 		}
 		for _, instance := range instances {
 			branch.AddNode(instance.AdditionalData.Name)

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -129,8 +129,8 @@ func PutInstance(instance models.CustomCheckInstanceModel, org, token, hostName 
 }
 
 // SyncOPAChecks syncs OPA checks
-func SyncOPAChecks(syncDir, org, insightsToken, host string, gitOps, dryrun bool) error {
-	results, err := CompareChecks(syncDir, org, insightsToken, host, gitOps)
+func SyncOPAChecks(syncDir, org, insightsToken, host string, fullsync, dryrun bool) error {
+	results, err := CompareChecks(syncDir, org, insightsToken, host, fullsync)
 	if err != nil {
 		return err
 	}

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -128,6 +128,7 @@ func PutInstance(instance models.CustomCheckInstanceModel, org, token, hostName 
 	return nil
 }
 
+// SyncOPAChecks syncs OPA checks
 func SyncOPAChecks(syncDir, org, insightsToken, host string, gitOps, dryrun bool) error {
 	results, err := CompareChecks(syncDir, org, insightsToken, host, gitOps)
 	if err != nil {

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package insights
+package opa
 
 import (
 	"errors"
 	"fmt"
 	"net/http"
 
-	"github.com/fairwindsops/insights-plugins/opa/pkg/opa"
+	opaPlugin "github.com/fairwindsops/insights-plugins/opa/pkg/opa"
 	"github.com/imroc/req"
 	"github.com/sirupsen/logrus"
 
@@ -34,14 +34,14 @@ const opaCheckInstancesURLFormat = opaCheckURLFormat + "/instances"
 const opaInstanceURLFormat = opaCheckInstancesURLFormat + "/%s"
 
 // GetChecks queries Fairwinds Insights to retrieve all of the Checks for an organization
-func GetChecks(org, token, hostName string) ([]opa.OPACustomCheck, error) {
+func GetChecks(org, token, hostName string) ([]opaPlugin.OPACustomCheck, error) {
 	url := fmt.Sprintf(opaURLFormat, hostName, org)
-	logrus.Infof("Url: %s", url)
+	logrus.Infof("OPA URL: %s", url)
 	resp, err := req.Get(url, getHeaders(token))
 	if err != nil {
 		return nil, err
 	}
-	var checks []opa.OPACustomCheck
+	var checks []opaPlugin.OPACustomCheck
 	if resp.Response().StatusCode != http.StatusOK {
 		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
 		return nil, errors.New("invalid response code")
@@ -54,7 +54,7 @@ func GetChecks(org, token, hostName string) ([]opa.OPACustomCheck, error) {
 }
 
 // GetInstances queries Fairwinds Insights to retrieve all of the instances for a given check
-func GetInstances(org, checkName, token, hostName string) ([]opa.CheckSetting, error) {
+func GetInstances(org, checkName, token, hostName string) ([]opaPlugin.CheckSetting, error) {
 	url := fmt.Sprintf(opaCheckInstancesURLFormat, hostName, org, checkName)
 	resp, err := req.Get(url, getHeaders(token))
 	if err != nil {
@@ -64,7 +64,7 @@ func GetInstances(org, checkName, token, hostName string) ([]opa.CheckSetting, e
 		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
 		return nil, errors.New("invalid response code")
 	}
-	var instances []opa.CheckSetting
+	var instances []opaPlugin.CheckSetting
 	err = resp.ToJSON(&instances)
 	if err != nil {
 		return nil, err
@@ -124,6 +124,68 @@ func PutInstance(instance models.CustomCheckInstanceModel, org, token, hostName 
 	if resp.Response().StatusCode != http.StatusOK {
 		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
 		return errors.New("invalid response code")
+	}
+	return nil
+}
+
+func SyncOPAChecks(syncDir, org, insightsToken, host string, gitOps, dryrun bool) error {
+	results, err := CompareChecks(syncDir, org, insightsToken, host, gitOps)
+	if err != nil {
+		return err
+	}
+	for _, instance := range results.InstanceDelete {
+		logrus.Infof("Deleting instance: %s:%s", instance.CheckName, instance.InstanceName)
+		if !dryrun {
+			err := DeleteInstance(instance, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, check := range results.CheckDelete {
+		logrus.Infof("Deleting check: %s", check.CheckName)
+		if !dryrun {
+			err := DeleteCheck(check, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, check := range results.CheckInsert {
+		logrus.Infof("Adding check: %s", check.CheckName)
+		if !dryrun {
+			err := PutCheck(check, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, check := range results.CheckUpdate {
+		logrus.Infof("Updating check: %s", check.CheckName)
+		if !dryrun {
+			err := PutCheck(check, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, instance := range results.InstanceInsert {
+		logrus.Infof("Adding instance: %s:%s", instance.CheckName, instance.InstanceName)
+		if !dryrun {
+			err := PutInstance(instance, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, instance := range results.InstanceUpdate {
+		logrus.Infof("Updating instance: %s:%s", instance.CheckName, instance.InstanceName)
+		if !dryrun {
+			err := PutInstance(instance, org, insightsToken, host)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -135,15 +135,15 @@ func BuildRulesTree(org, token, hostName string, tree treeprint.Tree) error {
 			rulesNode.AddNode(value)
 		}
 		if rule.Context != "" {
-			value := fmt.Sprintf("Context: %s", rule.Context)
+			value := fmt.Sprintf("Repository: %s", rule.Repository)
 			rulesNode.AddNode(value)
 		}
 		if rule.Repository != "" {
-			value := fmt.Sprintf("Cluster: %s", rule.Repository)
+			value := fmt.Sprintf("Repository: %s", rule.Repository)
 			rulesNode.AddNode(value)
 		}
 		if rule.ReportType != "" {
-			value := fmt.Sprintf("Cluster: %s", rule.ReportType)
+			value := fmt.Sprintf("Report Type: %s", rule.ReportType)
 			rulesNode.AddNode(value)
 		}
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -256,7 +256,7 @@ func compareRules(folder, org, token, hostName string) (CompareResults, error) {
 }
 
 // SyncRules syncs rules to insights
-func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
+func SyncRules(syncDir, org, insightsToken, host string, fullsync, dryrun bool) error {
 	results, err := compareRules(syncDir, org, insightsToken, host)
 	if err != nil {
 		logrus.Errorf("Unable to get sync rules to insights: %v", err)
@@ -265,7 +265,7 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 
 	for _, ruleForInsert := range results.RuleInsert {
 		logrus.Infof("Adding rule: %s", ruleForInsert.Name)
-		if !dryRun {
+		if !dryrun {
 			err = insertRule(org, insightsToken, host, ruleForInsert)
 			if err != nil {
 				logrus.Errorf("Error while adding rule %s to insights: %v", ruleForInsert.Name, err)
@@ -276,7 +276,7 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 
 	for _, ruleForUpdate := range results.RuleUpdate {
 		logrus.Infof("Updating rule: %s", ruleForUpdate.Name)
-		if !dryRun {
+		if !dryrun {
 			err = updateRule(org, insightsToken, host, ruleForUpdate)
 			if err != nil {
 				logrus.Errorf("Error while updating rule %s to insights: %v", ruleForUpdate.Name, err)
@@ -285,13 +285,15 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 		}
 	}
 
-	for _, ruleForDelete := range results.RuleDelete {
-		logrus.Infof("Deleting rule: %s", ruleForDelete.Name)
-		if !dryRun {
-			err = deleteRule(org, insightsToken, host, ruleForDelete)
-			if err != nil {
-				logrus.Errorf("Error while deleting rule %s from insights: %v", ruleForDelete.Name, err)
-				return err
+	if fullsync {
+		for _, ruleForDelete := range results.RuleDelete {
+			logrus.Infof("Deleting rule: %s", ruleForDelete.Name)
+			if !dryrun {
+				err = deleteRule(org, insightsToken, host, ruleForDelete)
+				if err != nil {
+					logrus.Errorf("Error while deleting rule %s from insights: %v", ruleForDelete.Name, err)
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,0 +1,290 @@
+// Copyright 2020 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"github.com/fairwindsops/insights-cli/pkg/directory"
+	"github.com/imroc/req"
+	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
+	"github.com/xlab/treeprint"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+	"net/http"
+)
+
+const rulesURLFormat = "%s/v0/organizations/%s/rules"
+const rulesURLFormatCreate = "%s/v0/organizations/%s/rules/create"
+const rulesURLFormatUpdateDelete = "%s/v0/organizations/%s/rules/%d"
+
+type Rule struct {
+	ID          int
+	Cluster     string
+	Name        string
+	Description string
+	Context     string
+	ReportType  string `json:"reportType" yaml:"reportType"`
+	Repository  string
+	Action      string
+}
+
+type CompareResults struct {
+	RuleInsert []Rule
+	RuleUpdate []Rule
+	RuleDelete []Rule
+}
+
+// getRules queries Fairwinds Insights to retrieve all of the Rules for an organization
+func getRules(org, token, hostName string) ([]Rule, error) {
+	url := fmt.Sprintf(rulesURLFormat, hostName, org)
+	logrus.Infof("Rules URL: %s", url)
+	resp, err := req.Get(url, getHeaders(token))
+	if err != nil {
+		return nil, err
+	}
+	var rules []Rule
+	if resp.Response().StatusCode != http.StatusOK {
+		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
+		return nil, errors.New("invalid response code")
+	}
+	err = resp.ToJSON(&rules)
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+// insertRule adds a new rule
+func insertRule(org, token, hostName string, rule Rule) error {
+	url := fmt.Sprintf(rulesURLFormatCreate, hostName, org)
+	resp, err := req.Post(url, getHeaders(token), req.BodyJSON(&rule))
+	if err != nil {
+		return err
+	}
+	if resp.Response().StatusCode != http.StatusOK {
+		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
+		return errors.New("invalid response code")
+	}
+	return nil
+}
+
+// updateRule updates an existing rule
+func updateRule(org, token, hostName string, rule Rule) error {
+	url := fmt.Sprintf(rulesURLFormatUpdateDelete, hostName, org, rule.ID)
+	resp, err := req.Post(url, getHeaders(token), req.BodyJSON(&rule))
+	if err != nil {
+		return err
+	}
+	if resp.Response().StatusCode != http.StatusOK {
+		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
+		return errors.New("invalid response code")
+	}
+	return nil
+}
+
+// deleteRule deletes an existing rule
+func deleteRule(org, token, hostName string, rule Rule) error {
+	url := fmt.Sprintf(rulesURLFormatUpdateDelete, hostName, org, rule.ID)
+	resp, err := req.Delete(url, getHeaders(token), nil)
+	if err != nil {
+		return err
+	}
+	if resp.Response().StatusCode != http.StatusOK {
+		logrus.Errorf("Invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
+		return errors.New("invalid response code")
+	}
+	return nil
+}
+
+func BuildRulesTree(org, token, hostName string, tree treeprint.Tree) error {
+	rules, err := getRules(org, token, hostName)
+	if err != nil {
+		return err
+	}
+
+	rulesBranch := tree.AddBranch("rules")
+	for _, rule := range rules {
+		rulesNode := rulesBranch.AddBranch(rule.Name)
+		if rule.Cluster != "" {
+			value := fmt.Sprintf("Cluster: %s", rule.Cluster)
+			rulesNode.AddNode(value)
+		}
+		if rule.Context != "" {
+			value := fmt.Sprintf("Context: %s", rule.Context)
+			rulesNode.AddNode(value)
+		}
+		if rule.Repository != "" {
+			value := fmt.Sprintf("Cluster: %s", rule.Repository)
+			rulesNode.AddNode(value)
+		}
+		if rule.ReportType != "" {
+			value := fmt.Sprintf("Cluster: %s", rule.ReportType)
+			rulesNode.AddNode(value)
+		}
+	}
+
+	return nil
+}
+
+func getRulesFromFiles(files map[string][]string) ([]Rule, error) {
+	var rules []Rule
+	for _, ruleFiles := range files {
+		var rule Rule
+		for _, filePath := range ruleFiles {
+			fileContents, err := ioutil.ReadFile(filePath)
+			if err != nil {
+				logrus.Error(err, "Error reading file", filePath)
+				return nil, err
+			}
+			err = yaml.Unmarshal(fileContents, &rule)
+			if err != nil {
+				logrus.Error(err, "Error Unmarshalling check YAML", filePath)
+				return nil, err
+			}
+			if rule.Name == "" {
+				return nil, fmt.Errorf("Rule name is empty in file: %s", filePath)
+			}
+			if rule.Action == "" {
+				return nil, fmt.Errorf("Rule action is empty in file: %s", filePath)
+			}
+			rules = append(rules, rule)
+		}
+	}
+	return rules, nil
+}
+
+func mapRulesWithName(rules []Rule) map[string]Rule {
+	return funk.Map(rules, func(value Rule) (string, Rule) {
+		return value.Name, value
+	}).(map[string]Rule)
+}
+
+func ruleNeedsUpdate(fileRule, existingRule Rule) bool {
+	if fileRule.Description != existingRule.Description {
+		return true
+	}
+	if fileRule.Context != existingRule.Context {
+		return true
+	}
+	if fileRule.Cluster != existingRule.Cluster {
+		return true
+	}
+	if fileRule.ReportType != existingRule.ReportType {
+		return true
+	}
+	if fileRule.Repository != existingRule.Repository {
+		return true
+	}
+	if fileRule.Action != existingRule.Action {
+		return true
+	}
+
+	return false
+}
+
+func getRuleDifferences(fileRules, existingRules []Rule) CompareResults {
+	mappedFileRules := mapRulesWithName(fileRules)
+	mappedExistingRules := mapRulesWithName(existingRules)
+	var results CompareResults
+
+	for ruleName, fileRule := range mappedFileRules {
+		if existingRule, ok := mappedExistingRules[ruleName]; ok {
+			if ruleNeedsUpdate(fileRule, existingRule) {
+				fileRule.ID = existingRule.ID
+				results.RuleUpdate = append(results.RuleUpdate, fileRule)
+			}
+		} else {
+			results.RuleInsert = append(results.RuleInsert, fileRule)
+		}
+	}
+
+	for ruleName, existingRule := range mappedExistingRules {
+		if _, ok := mappedFileRules[ruleName]; !ok {
+			results.RuleDelete = append(results.RuleDelete, existingRule)
+		}
+	}
+	return results
+}
+
+// compareRules compares a folder vs the rules returned by the API.
+func compareRules(folder, org, token, hostName string) (CompareResults, error) {
+	var results CompareResults
+	files, err := directory.ScanFolder(folder)
+	if err != nil {
+		logrus.Error("Error scanning directory")
+		return results, err
+	}
+
+	fileRules, err := getRulesFromFiles(files)
+	if err != nil {
+		logrus.Error("Error reading checks from files")
+		return results, err
+	}
+	existingRules, err := getRules(org, token, hostName)
+	if err != nil {
+		logrus.Error("Error during API call")
+		return results, err
+	}
+
+	results = getRuleDifferences(fileRules, existingRules)
+	return results, nil
+}
+
+func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
+	results, err := compareRules(syncDir, org, insightsToken, host)
+	if err != nil {
+		return err
+	}
+
+	for _, ruleForInsert := range results.RuleInsert {
+		logrus.Infof("Adding rule: %s", ruleForInsert.Name)
+		if !dryRun {
+			err = insertRule(org, insightsToken, host, ruleForInsert)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, ruleForUpdate := range results.RuleUpdate {
+		logrus.Infof("Updating rule: %s", ruleForUpdate.Name)
+		if !dryRun {
+			err = updateRule(org, insightsToken, host, ruleForUpdate)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, ruleForDelete := range results.RuleDelete {
+		logrus.Infof("Deleting rule: %s", ruleForDelete.Name)
+		if !dryRun {
+			err = deleteRule(org, insightsToken, host, ruleForDelete)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getHeaders(token string) req.Header {
+	return req.Header{
+		"Authorization": fmt.Sprintf("Bearer %s", token),
+		"Accept":        "application/json",
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -54,6 +54,7 @@ func getRules(org, token, hostName string) ([]Rule, error) {
 	logrus.Infof("Rules URL: %s", url)
 	resp, err := req.Get(url, getHeaders(token))
 	if err != nil {
+		logrus.Errorf("Unable to get rules from insights: %v", err)
 		return nil, err
 	}
 	var rules []Rule
@@ -63,6 +64,7 @@ func getRules(org, token, hostName string) ([]Rule, error) {
 	}
 	err = resp.ToJSON(&rules)
 	if err != nil {
+		logrus.Errorf("Unable to convert response to json for rules: %v", err)
 		return nil, err
 	}
 	return rules, nil
@@ -73,6 +75,7 @@ func insertRule(org, token, hostName string, rule Rule) error {
 	url := fmt.Sprintf(rulesURLFormatCreate, hostName, org)
 	resp, err := req.Post(url, getHeaders(token), req.BodyJSON(&rule))
 	if err != nil {
+		logrus.Errorf("Unable to add rule %s to insights: %v", rule.Name, err)
 		return err
 	}
 	if resp.Response().StatusCode != http.StatusOK {
@@ -87,6 +90,7 @@ func updateRule(org, token, hostName string, rule Rule) error {
 	url := fmt.Sprintf(rulesURLFormatUpdateDelete, hostName, org, rule.ID)
 	resp, err := req.Post(url, getHeaders(token), req.BodyJSON(&rule))
 	if err != nil {
+		logrus.Errorf("Unable to update rule %s to insights: %v", rule.Name, err)
 		return err
 	}
 	if resp.Response().StatusCode != http.StatusOK {
@@ -101,6 +105,7 @@ func deleteRule(org, token, hostName string, rule Rule) error {
 	url := fmt.Sprintf(rulesURLFormatUpdateDelete, hostName, org, rule.ID)
 	resp, err := req.Delete(url, getHeaders(token), nil)
 	if err != nil {
+		logrus.Errorf("Unable to delete rule %s from insights: %v", rule.Name, err)
 		return err
 	}
 	if resp.Response().StatusCode != http.StatusOK {
@@ -113,6 +118,7 @@ func deleteRule(org, token, hostName string, rule Rule) error {
 func BuildRulesTree(org, token, hostName string, tree treeprint.Tree) error {
 	rules, err := getRules(org, token, hostName)
 	if err != nil {
+		logrus.Errorf("Unable to get rules from insights: %v", err)
 		return err
 	}
 
@@ -247,6 +253,7 @@ func compareRules(folder, org, token, hostName string) (CompareResults, error) {
 func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 	results, err := compareRules(syncDir, org, insightsToken, host)
 	if err != nil {
+		logrus.Errorf("Unable to get sync rules to insights: %v", err)
 		return err
 	}
 
@@ -255,6 +262,7 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 		if !dryRun {
 			err = insertRule(org, insightsToken, host, ruleForInsert)
 			if err != nil {
+				logrus.Errorf("Error while adding rule %s to insights: %v", ruleForInsert.Name, err)
 				return err
 			}
 		}
@@ -265,6 +273,7 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 		if !dryRun {
 			err = updateRule(org, insightsToken, host, ruleForUpdate)
 			if err != nil {
+				logrus.Errorf("Error while updating rule %s to insights: %v", ruleForUpdate.Name, err)
 				return err
 			}
 		}
@@ -275,6 +284,7 @@ func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 		if !dryRun {
 			err = deleteRule(org, insightsToken, host, ruleForDelete)
 			if err != nil {
+				logrus.Errorf("Error while deleting rule %s from insights: %v", ruleForDelete.Name, err)
 				return err
 			}
 		}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -17,20 +17,23 @@ package rules
 import (
 	"errors"
 	"fmt"
-	"github.com/fairwindsops/insights-cli/pkg/directory"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/imroc/req"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"github.com/xlab/treeprint"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"net/http"
+
+	"github.com/fairwindsops/insights-cli/pkg/directory"
 )
 
 const rulesURLFormat = "%s/v0/organizations/%s/rules"
 const rulesURLFormatCreate = "%s/v0/organizations/%s/rules/create"
 const rulesURLFormatUpdateDelete = "%s/v0/organizations/%s/rules/%d"
 
+// Rule is the struct to hold the information for a rule
 type Rule struct {
 	ID          int
 	Cluster     string
@@ -42,6 +45,7 @@ type Rule struct {
 	Action      string
 }
 
+// CompareResults holds the rules for inserting, updating, and deleting
 type CompareResults struct {
 	RuleInsert []Rule
 	RuleUpdate []Rule
@@ -115,6 +119,7 @@ func deleteRule(org, token, hostName string, rule Rule) error {
 	return nil
 }
 
+// BuildRulesTree builds a tree for rules
 func BuildRulesTree(org, token, hostName string, tree treeprint.Tree) error {
 	rules, err := getRules(org, token, hostName)
 	if err != nil {
@@ -250,6 +255,7 @@ func compareRules(folder, org, token, hostName string) (CompareResults, error) {
 	return results, nil
 }
 
+// SyncRules syncs rules to insights
 func SyncRules(syncDir, org, insightsToken, host string, dryRun bool) error {
 	results, err := compareRules(syncDir, org, insightsToken, host)
 	if err != nil {


### PR DESCRIPTION
- This adds rules engine to CLI
- Can List and sync rules with Insights for a given org
  - Each rule would be in a separate file
  - List outputs both OPA checks and rules
  - Sync only syncs either OPA checks or rules. Default is checks, passing `--rules` flag syncs rules instead
- Can perform dry run on the sync operation

TODO
- Update documentation with examples
- Add tests
