### PR TITLE
skip windows arm build during release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,13 @@ brews:
 builds:
 - ldflags:
   - -X main.version={{.Version}} -X main.commit={{.Commit}} -s -w
+  # golang.org/x/sys/windows
+  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:2852:38: undefined: WSAData
+  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:3125:51: undefined: Servent
+  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:3139:50: undefined: Servent
+  ignore:
+  - goos: windows
+    goarch: arm64
   main: ./cmd/insights
   goarch:
   - amd64


### PR DESCRIPTION
This is apparently not working, so we'll skip building windows arm binaries.