### PR TITLE
fwi-1507: No longer require configuration env var / file for `insights-cli vers…

### DIFF
--- a/cmd/insights/root.go
+++ b/cmd/insights/root.go
@@ -82,8 +82,8 @@ func init() {
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	// If this is the root command don't try to parse config
-	if cmd.Use == "insights" {
+	// If this is the root or version command don't try to parse config
+	if cmd.Use == "insights" || cmd.Use == "version" {
 		return
 	}
 	parsedLevel, err := logrus.ParseLevel(logLevel)


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
No longer require the CLI to be configured, to display its version.
Internal Ticket (manually added): https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1507