### PR TITLE
FWI-1486 - Update the Insights CLI to sync V2 CustomChecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+Please see [Github releases][] for a list of changes.
 
-## 0.1.0
-* Initial release
+[Github releases]: https://github.com/FairWindsOps/insights-cli/releases
+

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -31,6 +31,7 @@ type OutputModel struct {
 // CustomCheckModel is a model for the API endpoint to receive a Custom Check for OPA
 type CustomCheckModel struct {
 	CheckName string `json:"-" yaml:"-"`
+	Version   float32
 	Output    OutputModel
 	Rego      string
 	Instances []CustomCheckInstanceModel `json:"-" yaml:"-"`

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -209,6 +209,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 	for checkName, checkFiles := range files {
 		var check models.CustomCheckModel
 		var instances []models.CustomCheckInstanceModel
+		check.Version = 1.0
 		for _, filePath := range checkFiles {
 			fileContents, err := ioutil.ReadFile(filePath)
 			if err != nil {
@@ -220,7 +221,6 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 				if extension == ".rego" {
 					check.Rego = string(fileContents)
 				} else if extension == ".yaml" {
-
 					err = yaml.Unmarshal(fileContents, &check)
 					if err != nil {
 						logrus.Error(err, "Error Unmarshalling check YAML", filePath)
@@ -247,7 +247,6 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 		check.CheckName = checkName
 		if len(instances) == 0 {
 			check.Version = 2.0
-			logrus.Infof("%q will be processed as a V2 check as it has no accompanying instances.", checkName)
 		} else {
 			check.Instances = instances
 		}

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -245,7 +245,12 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 			}
 		}
 		check.CheckName = checkName
-		check.Instances = instances
+		if len(instances) == 0 {
+			check.Version = 2.0
+			logrus.Infof("%q will be processed as a V2 check as it has no accompanying instances.", checkName)
+		} else {
+			check.Instances = instances
+		}
 		checks = append(checks, check)
 	}
 	return checks, nil

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -209,6 +209,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 	for checkName, checkFiles := range files {
 		var check models.CustomCheckModel
 		var instances []models.CustomCheckInstanceModel
+		var onlyRegoFormat bool
 		check.Version = 1.0
 		for _, filePath := range checkFiles {
 			fileContents, err := ioutil.ReadFile(filePath)
@@ -219,6 +220,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 			if strings.HasPrefix(filepath.Base(filePath), "policy.") {
 				extension := filepath.Ext(filePath)
 				if extension == ".rego" {
+					onlyRegoFormat = true
 					check.Rego = string(fileContents)
 				} else if extension == ".yaml" {
 					err = yaml.Unmarshal(fileContents, &check)
@@ -245,7 +247,7 @@ func getChecksFromFiles(files map[string][]string) ([]models.CustomCheckModel, e
 			}
 		}
 		check.CheckName = checkName
-		if len(instances) == 0 {
+		if len(instances) == 0 && onlyRegoFormat {
 			check.Version = 2.0
 		} else {
 			check.Instances = instances

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -29,6 +29,7 @@ import (
 const opaURLFormat = "%s/v0/organizations/%s/opa/customChecks"
 
 const opaCheckURLFormat = opaURLFormat + "/%s"
+const opaPutCheckURLFormat = opaCheckURLFormat + "?version=%.1f"
 const opaCheckInstancesURLFormat = opaCheckURLFormat + "/instances"
 
 const opaInstanceURLFormat = opaCheckInstancesURLFormat + "/%s"
@@ -88,7 +89,7 @@ func DeleteCheck(check models.CustomCheckModel, org, token, hostName string) err
 
 // PutCheck upserts an OPA Check to Fairwinds Insights
 func PutCheck(check models.CustomCheckModel, org, token, hostName string) error {
-	url := fmt.Sprintf(opaCheckURLFormat, hostName, org, check.CheckName)
+	url := fmt.Sprintf(opaPutCheckURLFormat, hostName, org, check.CheckName, check.Version)
 	resp, err := req.Put(url, getHeaders(token), req.BodyJSON(&check))
 	if err != nil {
 		return err
@@ -153,7 +154,7 @@ func SyncOPAChecks(syncDir, org, insightsToken, host string, fullsync, dryrun bo
 		}
 	}
 	for _, check := range results.CheckInsert {
-		logrus.Infof("Adding check: %s", check.CheckName)
+		logrus.Infof("Adding v%.0f check: %s", check.Version, check.CheckName)
 		if !dryrun {
 			err := PutCheck(check, org, insightsToken, host)
 			if err != nil {
@@ -162,7 +163,7 @@ func SyncOPAChecks(syncDir, org, insightsToken, host string, fullsync, dryrun bo
 		}
 	}
 	for _, check := range results.CheckUpdate {
-		logrus.Infof("Updating check: %s", check.CheckName)
+		logrus.Infof("Updating v%.0f check: %s", check.Version, check.CheckName)
 		if !dryrun {
 			err := PutCheck(check, org, insightsToken, host)
 			if err != nil {


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* The `insights-cli policy sync` command should submit Rego-onlyCustomChecks that do not have  accompanying Instances; CheckSettings yaml, to Insights as V2 checks.
  * Rego-only means that the policy is specified in the `policy.rego` file.
  * Policies specified as `policy.yaml` are treated as V1 checks, to help be clear about other fields (severity, remediation) that could be included in that yaml NO LONGER applying to V2 checks.
* Update `CHANGELOG.md` to point at our releases, as GoReleaser manages a changelog within the Github release it creates.

The `policy sync` output now includes the check version, to help show how a check is being processed:
```
INFO[0000] OPA URL: http://localhost:3000/v0/organizations/acme-co/opa/customChecks 
INFO[0000] Adding v1 check: test                        
INFO[0000] Adding v2 check: test2                       
INFO[0000] Adding v2 check: test2.5                     
INFO[0000] Adding instance: test:deployments            
INFO[0000] Adding instance: test:deployments2           
INFO[0000] Rules URL: http://localhost:3000/v0/organizations/acme-co/rules 
```


[Internal Ticket FWI-1486](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1486)