### PR TITLE
FWI-108 - [cli] send version header to API

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ brews:
     system "#{bin}/insights version"
 builds:
 - ldflags:
-  - -X main.version={{.Version}} -X main.commit={{.Commit}} -s -w
+  - -X github.com/fairwindsops/insights-cli/pkg/version.version={{.Version}} -X github.com/fairwindsops/insights-cli/pkg/version.commit={{.Commit}} -s -w
   # golang.org/x/sys/windows
   # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:2852:38: undefined: WSAData
   # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:3125:51: undefined: Servent

--- a/cmd/insights/root.go
+++ b/cmd/insights/root.go
@@ -29,8 +29,6 @@ import (
 var logLevel string
 var insightsToken string
 var configFile string
-var version string
-var commit string
 var organization string
 
 var configurationObject configuration

--- a/cmd/insights/version.go
+++ b/cmd/insights/version.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	cliversion "github.com/fairwindsops/insights-cli/pkg/version"
 
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,6 @@ var versionCmd = &cobra.Command{
 	Short: "Prints the current version of the tool.",
 	Long:  `Prints the current version.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version: " + version + " Commit: " + commit)
+		fmt.Println(cliversion.String())
 	},
 }

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/fairwindsops/insights-cli/pkg/models"
+	cliversion "github.com/fairwindsops/insights-cli/pkg/version"
 )
 
 const opaURLFormat = "%s/v0/organizations/%s/opa/customChecks"
@@ -194,7 +195,8 @@ func SyncOPAChecks(syncDir, org, insightsToken, host string, fullsync, dryrun bo
 
 func getHeaders(token string) req.Header {
 	return req.Header{
-		"Authorization": fmt.Sprintf("Bearer %s", token),
-		"Accept":        "application/json",
+		"X-FAIRWINDS-CLI-VERSION": cliversion.GetVersion(),
+		"Authorization":           fmt.Sprintf("Bearer %s", token),
+		"Accept":                  "application/json",
 	}
 }

--- a/pkg/opa/opa_calls.go
+++ b/pkg/opa/opa_calls.go
@@ -195,7 +195,7 @@ func SyncOPAChecks(syncDir, org, insightsToken, host string, fullsync, dryrun bo
 
 func getHeaders(token string) req.Header {
 	return req.Header{
-		"X-FAIRWINDS-CLI-VERSION": cliversion.GetVersion(),
+		"X-Fairwinds-CLI-Version": cliversion.GetVersion(),
 		"Authorization":           fmt.Sprintf("Bearer %s", token),
 		"Accept":                  "application/json",
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,18 +1,22 @@
-// version stores the Insights CLI version, making it accessible by other
+// Package version stores the Insights CLI version, making it accessible by other
 // packages.
 package version
 
 var version string = "unknown"
 var commit string = "unknown"
 
+// String returns the version and git commit, as might be used as output for a
+// `version` command-line flag.
 func String() string {
 	return "Version: " + version + " Commit: " + commit
 }
 
+// GetVersion returns the version unexported variable.
 func GetVersion() string {
 	return version
 }
 
+// GetCommit returns the commit unexported variable.
 func GetCommit() string {
 	return commit
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+// version stores the Insights CLI version, making it accessible by other
+// packages.
+package version
+
+var version string = "unknown"
+var commit string = "unknown"
+
+func String() string {
+	return "Version: " + version + " Commit: " + commit
+}
+
+func GetVersion() string {
+	return version
+}
+
+func GetCommit() string {
+	return commit
+}


### PR DESCRIPTION

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Send the Insights CLI version number in the `X-FAIRWINDS-CLI-VERSION` header to the Insights API.

### What changes did you make?
The CLI version is moved from the main pkg to a new version pkg, which is sourced by main (for the CLI version command) and by the opa pkg when submitting requests to the API.

### Testing

* I verified the CLI sends the expected header when querying the API E.G. `insights-cli policy list`, by using tcpdump, and also pointing the CLI at [a Netcat listener](http://netcat.sourceforge.net/) instead of the Insights API.
* I verified `goerleaser` injects the version and commit into the correct new pkg / variables.

[Internal Ticket FWI-108](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-108)