### PR TITLE
FWI-469 - Add a docker image for the CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,11 @@ jobs:
       - *install_vault
       - rok8s/get_vault_env:
           vault_path: repo/global/env
-      - rok8s/get_vault_env:
-          vault_path: repo/insights-cli/env
       - rok8s/docker_login:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
+      - run: echo size of docker config: $(wc -l ~/.docker/config.json)
       - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
       - run:
           name: test
           command: |
-            go test ./pkg/...
-            go vet
+            go test ./...
+            go vet ./...
   snapshot:
     working_directory: /go/src/github.com/fairwindsops/insights-cli
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,8 @@
 version: 2.1
-
 orbs:
   rok8s: fairwinds/rok8s-scripts@11
 
 references:
-  enable_experimental_features: &enable_experimental_docker_features
-    run:
-      name: enable experimental features
-      command: |
-        set -ex
-        apk --update add openssh
-        ssh remote-docker \<<EOF
-          sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
-          sudo systemctl restart docker
-        EOF
   install_vault: &install_vault
     run:
       name: install hashicorp vault
@@ -51,7 +40,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.11
-      #- *enable_experimental_docker_features
       - run: goreleaser --snapshot
       # Avoid copying both archive files and the directories used to create them.
       - run: mkdir snapshot-artifacts && cp dist/*.tar.gz dist/*.txt dist/*.rb dist/*.json snapshot-artifacts
@@ -67,7 +55,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.11
-      #- *enable_experimental_docker_features
       - *install_vault
       - rok8s/get_vault_env:
           vault_path: repo/global/env
@@ -75,7 +62,6 @@ jobs:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
-      - run: wc -l ~/.docker/config.json
       - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,8 @@ jobs:
           name: lint
           command: |
             test -z $(go fmt ./...)
-            go install golang.org/x/lint/golint@latest
-            golint -set_exit_status ./...
-            go get honnef.co/go/tools/cmd/staticcheck
-            staticcheck ./pkg/...
+            go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+            golangci-lint run -v --timeout 2m0s
       - run:
           name: test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       #- *enable_experimental_docker_features
       - run: goreleaser --snapshot
       # Avoid copying both archive files and the directories used to create them.
-      - run: mkdir snapshot-artifacts && cp dist/*.tar.gz *checksums.txt insights.rb artifacts.json metadata.json snapshot-artifacts
+      - run: mkdir snapshot-artifacts && cp dist/*.tar.gz dist/*.txt dist/*.rb dist/*.json snapshot-artifacts
       - store_artifacts:
           path: snapshot-artifacts
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,49 +1,104 @@
 version: 2.1
 
+orbs:
+  rok8s: fairwinds/rok8s-scripts@11
+
+references:
+  enable_experimental_features: &enable_experimental_docker_features
+    run:
+      name: enable experimental features
+      command: |
+        set -ex
+        apk --update add openssh
+        ssh remote-docker \<<EOF
+          sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+          sudo systemctl restart docker
+        EOF
+  install_vault: &install_vault
+    run:
+      name: install hashicorp vault
+      command: |
+        apk --update add curl yq
+        cd /tmp
+        curl -LO https://releases.hashicorp.com/vault/1.9.2/vault_1.9.2_linux_amd64.zip
+        unzip vault_1.9.2_linux_amd64.zip
+        mv vault /usr/bin/vault
+
 jobs:
-  release:
+  test:
+    working_directory: /go/src/github.com/fairwindsops/insights-cli
+    docker:
+      - image: circleci/golang:1.17
+    steps:
+      - checkout
+      - run:
+          name: lint
+          command: |
+            test -z $(go fmt ./...)
+            go install golang.org/x/lint/golint@latest
+            golint -set_exit_status ./...
+            go get honnef.co/go/tools/cmd/staticcheck
+            staticcheck ./pkg/...
+      - run:
+          name: test
+          command: |
+            go test ./pkg/...
+            go vet
+  snapshot:
+    working_directory: /go/src/github.com/fairwindsops/insights-cli
     resource_class: large
     docker:
-      - image: cimg/go:1.17
+      - image: goreleaser/goreleaser:v1.6.3
     steps:
       - checkout
-      - run: |
-          curl -fsSLo goreleaser.deb https://github.com/goreleaser/goreleaser/releases/download/v0.184.0/goreleaser_amd64.deb
-          echo "6bddbabef03e51403568b70989c2ea20c5f021d0cba11411255a287e0f3fec3d goreleaser.deb" | sha256sum -c
-          sudo dpkg -i goreleaser.deb
-          git checkout -- .
-          git clean -df .
-          goreleaser
-
-  test:
+      - setup_remote_docker:
+          version: 20.10.11
+      #- *enable_experimental_docker_features
+      - run: goreleaser --snapshot
+      # Avoid copying both archive files and the directories used to create them.
+      - run: mkdir snapshot-artifacts && cp dist/*.tar.gz *checksums.txt insights.rb artifacts.json metadata.json snapshot-artifacts
+      - store_artifacts:
+          path: snapshot-artifacts
+  release:
+    working_directory: /go/src/github.com/fairwindsops/insights-cli
+    resource_class: large
+    shell: /bin/bash
     docker:
-      - image: cimg/go:1.17
+      - image: goreleaser/goreleaser:v1.6.3
     steps:
       - checkout
-      - run: |
-              go get -u golang.org/x/lint/golint
-              go get honnef.co/go/tools/cmd/staticcheck
-              go list ./pkg/... | grep -v vendor | xargs golint -set_exit_status
-              go list ./pkg/... | grep -v vendor | xargs go vet
-              staticcheck ./pkg/...
-              go test ./pkg/... -coverprofile=coverage.txt -covermode=count
+      - setup_remote_docker:
+          version: 20.10.11
+      #- *enable_experimental_docker_features
+      - *install_vault
+      - rok8s/get_vault_env:
+          vault_path: repo/global/env
+      - rok8s/docker_login:
+          registry: "quay.io"
+          username: $FAIRWINDS_QUAY_USER
+          password-variable: FAIRWINDS_QUAY_TOKEN
+      - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
+      - run: goreleaser
 
 workflows:
   version: 2
-  test:
+  test_and_build:
     jobs:
-      - test:
+      - test
+      - snapshot:
+          requires:
+            - test
           filters:
             branches:
               only: /.*/
             tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+              ignore: /.*/
+  release:
+    jobs:
       - release:
-          requires:
-          - test
+          context: org-global
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
-      - run: echo "size of docker config: $(wc -l ~/.docker/config.json)"
+      - run: wc -l ~/.docker/config.json
       - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,8 @@ jobs:
       - *install_vault
       - rok8s/get_vault_env:
           vault_path: repo/global/env
+      - rok8s/get_vault_env:
+          vault_path: repo/insights-cli/env
       - rok8s/docker_login:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
-      - run: echo size of docker config: $(wc -l ~/.docker/config.json)
+      - run: echo "size of docker config: $(wc -l ~/.docker/config.json)"
       - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 brews:
 - name: insights
+  # Do not update our tap repo if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_upload: auto
   goarm: 6
   tap:
     owner: FairwindsOps
@@ -11,21 +13,16 @@ brews:
 builds:
 - ldflags:
   - -X github.com/fairwindsops/insights-cli/pkg/version.version={{.Version}} -X github.com/fairwindsops/insights-cli/pkg/version.commit={{.Commit}} -s -w
-  # golang.org/x/sys/windows
-  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:2852:38: undefined: WSAData
-  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:3125:51: undefined: Servent
-  # ../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/windows/zsyscall_windows.go:3139:50: undefined: Servent
-  ignore:
-  - goos: windows
-    goarch: arm64
+  env:
+  - CGO_ENABLED=0
   main: ./cmd/insights
+  # goreleaser builds a matrix of the GOOS, GOArch, and GOARM listed below,
+  # minus those under `ignore`.
   goarch:
+  - 386
   - amd64
   - arm
   - arm64
-  - 386
-  env:
-  - CGO_ENABLED=0
   goos:
   - linux
   - darwin
@@ -33,9 +30,98 @@ builds:
   goarm:
   - 6
   - 7
+  ignore:
+  - goos: windows
+    goarch: arm64
 changelog:
   sort: asc
   filters:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^Managed by Terraform$'
+dockers:
+  # There are multiple images to match the `--platform` docker build flag with
+  # combinations of `GOOS`, `GOARCH`, and `GOARM`
+  # Also, some images are broken out to avoid pushing them for pre-release git
+  # tags. E.G. VX.Y.Z-rc1 should not docker-push latest.
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-amd64"
+  use: buildx
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-amd64"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-amd64"
+  use: buildx
+  # Do not push images if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-arm64v8"
+  use: buildx
+  goarch: arm64
+  goos: linux
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-arm64v8"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-arm64v8"
+  use: buildx
+  # Do not push images if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  goarch: arm64
+  goos: linux
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-armv7"
+  use: buildx
+  goarch: arm
+  goarm: 7
+  goos: linux
+  build_flag_templates:
+  - "--platform=linux/arm/v7"
+- image_templates:
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-armv7"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-armv7"
+  use: buildx
+  # Do not push images if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  goarch: arm
+  goarm: 7
+  goos: linux
+  build_flag_templates:
+  - "--platform=linux/arm/v7"
+docker_manifests:
+# Combine images of the same tag into a single Docker manifest.
+# E.G. An insights-cli:v1.2.3 manifest includes images
+# insights-cli:v1.2.3-amd64, ...:v1.2.3-arm64v8, ...:v1.2.3-armv7, Etc.
+- name_template: quay.io/fairwinds/insights-cli:latest
+  # Do not push manifests if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  image_templates:
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-amd64"
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-arm64v8"
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-armv7"
+- name_template: quay.io/fairwinds/insights-cli:{{ .Tag }}
+  image_templates:
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-amd64"
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-arm64v8"
+  - "quay.io/fairwinds/insights-cli:{{ .Tag }}-armv7"
+- name_template: quay.io/fairwinds/insights-cli:v{{ .Major }}
+  # Do not push manifests if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  image_templates:
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-amd64"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-arm64v8"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}-armv7"
+- name_template: quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}
+  # Do not push manifests if the git tag indicates prerelease. E.G. 1.0.0-rc1
+  skip_push: auto
+  image_templates:
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-amd64"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-arm64v8"
+  - "quay.io/fairwinds/insights-cli:v{{ .Major }}.{{ .Minor }}-armv7"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
-FROM alpine:latest
-
-ARG INSIGHTS_CLI_VERSION ${INSIGHTS_CLI_VERSION}
-ENV RELEASE_URL "https://github.com/FairwindsOps/insights-cli/releases/download/v${INSIGHTS_CLI_VERSION}/insights-cli_${INSIGHTS_CLI_VERSION}_linux_amd64.tar.gz"
-
-WORKDIR /
-
-RUN mkdir -p /build && cd build && \
-    wget $RELEASE_URL && \
-    tar -xvf insights-cli_${INSIGHTS_CLI_VERSION}_linux_amd64.tar.gz insights-cli -C /usr/local/bin/ && \
-    chmod a+x /usr/local/bin/insights-cli && \
-    rm -rf /build
-
-CMD /usr/local/bin/insights-cli
+FROM alpine:3.15
+USER nobody
+# The insights-cli binary will have been built by goreleaser.
+COPY insights-cli /
+CMD ["/insights-cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:3.15
 USER nobody
 # The insights-cli binary will have been built by goreleaser.
 COPY insights-cli /
-CMD ["/insights-cli"]
+ENTRYPOINT ["/insights-cli"]


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Build and push Docker images using GoReleaser, also requiring CircleCI integration with our image registry.

Bullets for CLI docker push PR:

See also:
* The [Github release 1.0.0-alpha1](https://github.com/FairwindsOps/insights-cli/releases/tag/v1.0.0-alpha1) which I manually checked as a pre-release in Github.
* [insights-cli on Quay](https://quay.io/repository/fairwinds/insights-cli?tab=tags), where a pre-release has been pushed by CI.

When a branch is pushed:
* A GoReleaser snapshot is built, CI artifacts include the `.tar.gz` archives and other GoReleaser-generated content such as the Homebrew tap `insights.rb`.
* No Docker images are pushed, nor Github releases created.

When a pre-release tag is pushed, such as v1.0.0-alpha1:
* A Docker image is pushed with tag matching the git tag, but *not* matching the Git commit.
* No Github release is created.

When a release tag is pushed, such as v1.0.0:
* A Docker image is pushed with tag matching the git tag, but *not* matching the Git commit (as above).
* Docker images are pushed with tags of the form `VX`, `VX.Y`, and `latest` tags.
* A Github release is created, using ascending git-commits for the ChangeLog, factoring out some commits such as `Managed by Terraform`.

* 
### What changes did you make?
* Update GoReleaser config to support Docker images, and multi-image manifests (multi-architecture builds).
*Update CircleCI config to
  * Authenticate to Quay
  * Use a newer GoReleaser and CircleCI Docker
  * Avoid copying the full 604Mb of the GoReleaser `dist` directory (duplicated builds + build archives)


[Internal Ticket FWI-469](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-469)