### PR TITLE
FWI-184 - [cli] help text

### DIFF
--- a/cmd/insights/root.go
+++ b/cmd/insights/root.go
@@ -16,13 +16,11 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
 
@@ -74,9 +72,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", logrus.InfoLevel.String(), "Logrus log level.")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "./fairwinds-insights.yaml", "Configuration file")
 	rootCmd.PersistentFlags().StringVarP(&organization, "organization", "", "", "Fairwinds Insights Organization name")
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	flag.Parse()
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
 func preRun(cmd *cobra.Command, args []string) {

--- a/cmd/insights/root.go
+++ b/cmd/insights/root.go
@@ -116,7 +116,7 @@ func preRun(cmd *cobra.Command, args []string) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:              "insights",
+	Use:              "insights-cli",
 	Short:            "insights",
 	Long:             `Interact with Fairwinds Insights.`,
 	PersistentPreRun: preRun,

--- a/cmd/insights/sync.go
+++ b/cmd/insights/sync.go
@@ -55,7 +55,7 @@ var syncCmd = &cobra.Command{
 			if err != nil {
 				logrus.Fatalf("Unable to sync OPA Checks: %v", err)
 			}
-
+			logrus.Infoln("Policy sync complete")
 		}
 		if !forChecks || forRules {
 			rulesDir := syncDir + "/rules"
@@ -67,6 +67,7 @@ var syncCmd = &cobra.Command{
 			if err != nil {
 				logrus.Fatalf("Unable to sync rules: %v", err)
 			}
+			logrus.Infoln("Rules sync complete")
 		}
 
 	},


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Fix the `insights-cli --help` option which currently displays nothing.
* Add more feedback to the output for `policy sync` so users know there was success. RE: the ticket stating: policy sync doesn't confirm success, or log what's happening
  * This may have been an old ticket / state of things - the `policy sync` command already output what was happening, but not necessarily a "success / we're done" message.

### What changes did you make?
* Removed unnecessary use of `flag` and flag processing taking place outside of what Cobra already does. This was ignoring Cobra command-line flags `--help` `--log-level`, Etc.


[Internal Ticket FWI-184](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-184)