### PR TITLE
FWI-1749 - Update the Insights CLI to bulk-validate OPA for use in CI

### DIFF
--- a/cmd/insights/root.go
+++ b/cmd/insights/root.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -76,10 +77,12 @@ func insightsAPINotRequired(cmd *cobra.Command) bool {
 	return cmd.Use == "help [command]" ||
 		cmd.Use == "insights-cli" ||
 		cmd.Use == "validate" ||
-		(cmd.Parent().Use == "validate" && cmd.Use == "opa")
+		(cmd.Parent().Use == "validate" && strings.HasPrefix(cmd.Use, "opa "))
 }
 
 func init() {
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true, DisableLevelTruncation: true})
+
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", logrus.InfoLevel.String(), "Logrus log level.")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "./fairwinds-insights.yaml", "Configuration file")
 	rootCmd.PersistentFlags().StringVarP(&organization, "organization", "", "", "Fairwinds Insights Organization name")

--- a/cmd/insights/validate.go
+++ b/cmd/insights/validate.go
@@ -13,10 +13,9 @@ import (
 
 // validateCmd represents the validate command
 var validateCmd = &cobra.Command{
-	Use:              "validate",
-	Short:            "Validate files for use with Insights",
-	Long:             `Validate files used with Insights, before submitting them to the Insights API`,
-	TraverseChildren: true,
+	Use:   "validate",
+	Short: "Validate files for use with Insights",
+	Long:  `Validate files used with Insights, before submitting them to the Insights API`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.Error("Please specify a sub-command.")
 		err := cmd.Help()

--- a/cmd/insights/validate_opa.go
+++ b/cmd/insights/validate_opa.go
@@ -10,36 +10,81 @@ import (
 
 	"github.com/fairwindsops/insights-cli/pkg/opavalidation"
 	fwrego "github.com/fairwindsops/insights-plugins/plugins/opa/pkg/rego"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var regoFileName, objectFileName, objectNamespaceOverride, insightsInfoCluster, insightsInfoContext string
+var regoFileName, objectFileName, batchDir, objectNamespaceOverride, insightsInfoCluster, insightsInfoContext string
 
-// opaCmd represents the validate opa command
-var opaCmd = &cobra.Command{
-	Use:              "opa",
-	Short:            "Validate the syntax and output of a V2 Insights OPA policy",
-	Long:             `opa checks a V2 format Insights OPA policy for rego syntax and proper action item output.`,
-	TraverseChildren: true,
+// OPACmd represents the validate opa command
+var OPACmd = &cobra.Command{
+	Use:   "opa {-r <policy file> -k <Kube manifest file> | -b <directory of policies and manifests>} [flags]",
+	Short: "Validate the syntax and output of a V2 Insights OPA policy",
+	Long:  `opa runs V2 format Insights OPA policies with a Kubernetes manifest as input, validating rego syntax and proper Insights action item output.`,
+	Example: `
+	To validate a single policy: insights-cli validate opa -r policy.rego -k input-manifest.yaml
+
+	To validate a directory of policies and Kubernetes manifests, with a policy and its corresponding Kubernetes manifest sharing the same base filename: insights-cli validate opa -b ./all_policies`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := opavalidation.Run(regoFileName, objectFileName, fwrego.InsightsInfo{InsightsContext: insightsInfoContext, Cluster: insightsInfoCluster}, objectNamespaceOverride)
-		if err != nil {
-			fmt.Printf("OPA policy failed validation: %v\n", err)
+		if !checkValidateOPAFlags() {
+			err := cmd.Help()
+			if err != nil {
+				logrus.Error(err)
+			}
 			os.Exit(1)
 		}
-		fmt.Println("OPA policy validated successfully.")
+		if regoFileName != "" {
+			_, err := opavalidation.Run(regoFileName, objectFileName, fwrego.InsightsInfo{InsightsContext: insightsInfoContext, Cluster: insightsInfoCluster}, objectNamespaceOverride)
+			if err != nil {
+				fmt.Printf("OPA policy failed validation: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("OPA policy validated successfully.")
+		}
+
+		if batchDir != "" {
+			_, failedPolicies, err := opavalidation.RunBatch(batchDir, fwrego.InsightsInfo{InsightsContext: insightsInfoContext, Cluster: insightsInfoCluster}, objectNamespaceOverride)
+			fmt.Println() // separate output from RunBatch
+			if err != nil {
+				fmt.Printf("OPA policies failed validation: %v\n", err)
+				fmt.Printf("Please check the above output for details about the %s\n", opavalidation.HumanizeStringsOutput(failedPolicies, "failure"))
+				os.Exit(1)
+			}
+			fmt.Println("OPA policies validated successfully.")
+		}
 	},
 }
 
-func init() {
-	validateCmd.AddCommand(opaCmd)
-	opaCmd.Flags().StringVarP(&regoFileName, "rego-file", "r", "policy.rego", "The rego file to validate.")
-	opaCmd.Flags().StringVarP(&objectFileName, "kube-object-file", "k", "", "A Kubernetes manifest to provide as input to the rego policy.")
-	opaCmd.Flags().StringVarP(&objectNamespaceOverride, "object-namespace", "N", "", "A Kubernetes namespace to override any defined in the object-file.")
-	opaCmd.Flags().StringVarP(&insightsInfoCluster, "insightsinfo-cluster", "l", "test", "A Kubernetes cluster name returned by the Insights-provided insightsinfo() rego function.")
-	opaCmd.Flags().StringVarP(&insightsInfoContext, "insightsinfo-context", "t", "Agent", "An Insights context returned by the Insights-provided insightsinfo() rego function. The context returned by Insights plugins is typically one of: CI/CD, Admission, or Agent.")
-	err := opaCmd.MarkFlagRequired("kube-object-file")
-	if err != nil {
-		panic(fmt.Errorf("unable to mark flag persistent: %v", err))
+// checkValidateOPAFlags verifies supplied flags for `validate opa` are valid.
+func checkValidateOPAFlags() bool {
+	var validFlags bool = true
+	if batchDir == "" && regoFileName == "" {
+		logrus.Errorln("Please specify one of the --rego-file or --batch-directory options to validate one or more OPA policies.")
+		return false
 	}
+	if batchDir != "" {
+		if regoFileName != "" {
+			logrus.Errorln("Please specify only one of the --batch-directory or --rego-file options.")
+			return false
+		}
+		if objectFileName != "" {
+			logrus.Errorln("The --kube-object-file option is only used with the --rego-file option, to validate a single OPA policy.")
+			return false
+		}
+	}
+	if regoFileName != "" && objectFileName == "" {
+		logrus.Errorln("Please also specify a Kube object file when validating a single OPA policy, using the --kube-object-file option.")
+		return false
+	}
+	return validFlags
+}
+
+func init() {
+	validateCmd.AddCommand(OPACmd)
+	OPACmd.Flags().StringVarP(&batchDir, "batch-directory", "b", "", "A directory containing OPA policy .rego files and corresponding Kubernetes manifest .yaml input files to validate. This option validates multiple OPA policies at once, and is mutually exclusive with the rego-file option.")
+	OPACmd.Flags().StringVarP(&regoFileName, "rego-file", "r", "", "An OPA policy file containing rego to validate. The --kube-object-file option is also required. This option validates a single policy, and is mutually exclusive with the batch-directory option.")
+	OPACmd.Flags().StringVarP(&objectFileName, "kube-object-file", "k", "", "A Kubernetes manifest to provide as input when validating a single OPA policy. This option is mutually exclusive with the batch-directory option.")
+	OPACmd.Flags().StringVarP(&objectNamespaceOverride, "object-namespace", "N", "", "A Kubernetes namespace to override any defined in the Kubernetes object being passed as input to an OPA policy.")
+	OPACmd.Flags().StringVarP(&insightsInfoCluster, "insightsinfo-cluster", "l", "test", "A Kubernetes cluster name returned by the Insights-provided insightsinfo() rego function.")
+	OPACmd.Flags().StringVarP(&insightsInfoContext, "insightsinfo-context", "t", "Agent", "An Insights context returned by the Insights-provided insightsinfo() rego function. The context returned by Insights plugins is typically one of: CI/CD, Admission, or Agent.")
 }

--- a/cmd/insights/validate_opa.go
+++ b/cmd/insights/validate_opa.go
@@ -57,7 +57,6 @@ var OPACmd = &cobra.Command{
 
 // checkValidateOPAFlags verifies supplied flags for `validate opa` are valid.
 func checkValidateOPAFlags() bool {
-	var validFlags bool = true
 	if batchDir == "" && regoFileName == "" {
 		logrus.Errorln("Please specify one of the --rego-file or --batch-directory options to validate one or more OPA policies.")
 		return false
@@ -76,7 +75,7 @@ func checkValidateOPAFlags() bool {
 		logrus.Errorln("Please also specify a Kube object file when validating a single OPA policy, using the --kube-object-file option.")
 		return false
 	}
-	return validFlags
+	return true
 }
 
 func init() {

--- a/pkg/opavalidation/opavalidation.go
+++ b/pkg/opavalidation/opavalidation.go
@@ -122,9 +122,7 @@ func runRegoForObject(ctx context.Context, regoAsString string, object map[strin
 			},
 			func(_ rego.BuiltinContext, _ *ast.Term, _ *ast.Term) (*ast.Term, error) {
 				logrus.Warnln("NOTE: The rego kubernetes function currently does not return data when validating OPA policies.")
-				returnArray := make([]string, 1)
-				returnArray[0] = "the rego kubernetes function currently does not return data when validating OPA policies"
-				returnData, err := ast.InterfaceToValue(returnArray)
+				returnData, err := ast.InterfaceToValue([]string{"the rego kubernetes function currently does not return data when validating OPA policies"})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/opavalidation/opavalidation.go
+++ b/pkg/opavalidation/opavalidation.go
@@ -121,9 +121,14 @@ func runRegoForObject(ctx context.Context, regoAsString string, object map[strin
 				Decl: types.NewFunction(types.Args(types.S, types.S), types.A),
 			},
 			func(_ rego.BuiltinContext, _ *ast.Term, _ *ast.Term) (*ast.Term, error) {
-				// Perhaps do something mroe here to communicate it isn't possible to fetch
-				// cluster resources?
-				return nil, nil
+				logrus.Warnln("NOTE that the rego kubernetes function currently does not return data when validating OPA policies.")
+				returnArray := make([]string, 1)
+				returnArray[0] = "the rego kubernetes function currently does not return data when validating OPA policies"
+				returnData, err := ast.InterfaceToValue(returnArray)
+				if err != nil {
+					return nil, err
+				}
+				return ast.NewTerm(returnData), nil
 			},
 		),
 		rego.Function1(

--- a/pkg/opavalidation/opavalidation.go
+++ b/pkg/opavalidation/opavalidation.go
@@ -18,6 +18,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	DefaultKubeObjectNamespace = "notset" // The namespace to use if one is unspecified
+)
+
 // Run is a ValidateRego() wrapper that validates and prints resulting actionItems. This is
 // meant to be called from a cobra.Command{}.
 func Run(regoFileName, objectFileName string, insightsInfo fwrego.InsightsInfo, objectNamespaceOverride string) (actionItems, error) {

--- a/pkg/opavalidation/opavalidation.go
+++ b/pkg/opavalidation/opavalidation.go
@@ -121,7 +121,7 @@ func runRegoForObject(ctx context.Context, regoAsString string, object map[strin
 				Decl: types.NewFunction(types.Args(types.S, types.S), types.A),
 			},
 			func(_ rego.BuiltinContext, _ *ast.Term, _ *ast.Term) (*ast.Term, error) {
-				logrus.Warnln("NOTE that the rego kubernetes function currently does not return data when validating OPA policies.")
+				logrus.Warnln("NOTE: The rego kubernetes function currently does not return data when validating OPA policies.")
 				returnArray := make([]string, 1)
 				returnArray[0] = "the rego kubernetes function currently does not return data when validating OPA policies"
 				returnData, err := ast.InterfaceToValue(returnArray)

--- a/pkg/opavalidation/opavalidation.go
+++ b/pkg/opavalidation/opavalidation.go
@@ -15,34 +15,65 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/types"
+	"github.com/sirupsen/logrus"
 )
 
-// Run is a ValidateRego() wrapper that prints resulting actionItems. This is
+// Run is a ValidateRego() wrapper that validates and prints resulting actionItems. This is
 // meant to be called from a cobra.Command{}.
-func Run(regoFileName, objectFileName string, insightsInfo fwrego.InsightsInfo, objectNamespaceOverride string) error {
+func Run(regoFileName, objectFileName string, insightsInfo fwrego.InsightsInfo, objectNamespaceOverride string) (actionItems, error) {
 	b, err := ioutil.ReadFile(regoFileName)
 	if err != nil {
-		return fmt.Errorf("error reading %s: %v", regoFileName, err)
+		return nil, fmt.Errorf("error reading OPA policy %s: %v", regoFileName, err)
 	}
 	regoContent := string(b)
 	b, err = ioutil.ReadFile(objectFileName)
 	if err != nil {
-		return fmt.Errorf("error reading %s: %v", objectFileName, err)
+		return nil, fmt.Errorf("error reading Kubernetes manifest %s: %v", objectFileName, err)
 	}
 	baseRegoFileName := filepath.Base(regoFileName)
 	eventType := strings.TrimSuffix(baseRegoFileName, filepath.Ext(baseRegoFileName))
 	actionItems, err := ValidateRego(context.TODO(), regoContent, b, insightsInfo, eventType, objectNamespaceOverride)
 	if err != nil {
-		return err
+		return actionItems, err
 	}
 	actionItemsAsString, err := actionItems.StringWithValidation()
 	// If actionItems have errors, output the actionItems first to display more
 	// specific inline errors.
 	fmt.Println(actionItemsAsString)
 	if err != nil {
-		return err
+		return actionItems, err
 	}
-	return nil
+	if len(actionItems) != 1 {
+		return actionItems, fmt.Errorf("%d action items were returned, but 1 is required", len(actionItems))
+	}
+	return actionItems, nil
+}
+
+// RunBatch is a Run() wrapper that processes multiple OPA policies. It does
+// not return the actionItems from each call to Run(), as there would not be correlation of
+// actionItems to their OPA policy.
+// This is meant to be called from a cobra.Command{}.
+func RunBatch(batchDir string, insightsInfo fwrego.InsightsInfo, objectNamespaceOverride string) (successfulPolicies, failedPolicies []string, err error) {
+	regoFiles, err := FindFilesWithExtension(batchDir, ".rego")
+	if err != nil {
+		return successfulPolicies, failedPolicies, fmt.Errorf("unable to list .rego files: %v", err)
+	}
+	for _, regoFileName := range regoFiles {
+		objectFileName := strings.TrimSuffix(regoFileName, filepath.Ext(regoFileName)) + ".yaml"
+		logrus.Infof("Starting validation of OPA policy %s with input %s\n", regoFileName, objectFileName)
+		_, err := Run(regoFileName, objectFileName, insightsInfo, objectNamespaceOverride)
+		if err != nil {
+			logrus.Errorf("Failed validation of OPA policy %s: %v\n", regoFileName, err)
+			failedPolicies = append(failedPolicies, regoFileName)
+		} else {
+			logrus.Infof("Success validating OPA policy %s\n", regoFileName)
+			successfulPolicies = append(successfulPolicies, regoFileName)
+		}
+	}
+	if len(failedPolicies) > 0 {
+		return successfulPolicies, failedPolicies, fmt.Errorf("%d failed  and %d succeeded", len(failedPolicies), len(successfulPolicies))
+	}
+	return successfulPolicies, failedPolicies, nil
 }
 
 // ValidateRego validates rego by executing rego with an input object.

--- a/pkg/opavalidation/types.go
+++ b/pkg/opavalidation/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
 )
 
 // Type actionItem represents an Insights action item.
@@ -63,7 +64,8 @@ func (AI *actionItem) setFieldsFromObject(obj map[string]interface{}) error {
 	AI.ResourceName = objName
 	objNamespace, err := getStringField(objMetadata, "namespace")
 	if err != nil {
-		return fmt.Errorf("while getting the metadata.namespace from the Kubernetes object: %v", err)
+		logrus.Debugf("Using namespace %q, as getting the metadata.namespace from the Kubernetes object returned: %v", DefaultKubeObjectNamespace, err)
+		objNamespace = DefaultKubeObjectNamespace
 	}
 	AI.ResourceNamespace = objNamespace
 	return nil


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Fix OPA validation bug: a missing Kube manifest namespace caused validation to fail. Now if the namespace is missing from the manifest, a default value `notset` is used.
* Until this functionality is added, update the rego `kubernetes` function to log a warning and return an array with `the rego kubernetes function currently does not return data when validating OPA policies`
* Add bulk validation of OPA policies, for use in CI workflows.
* Update OPA validation to require a single action item. Multiple action items are seen as duplicate by the Insights API.

## Sample Output
Bulk validation shows actionItems (even if more than one), and inline errors about invalid aspects of a policy. The end of the output lists which policies have failed, so the user is aware of which output to look at for additional detail above.

### Mixed Success and Failure Validation Output
```
$ ./cli validate opa --batch-directory bulk-mixed-validation
INFO Starting validation of OPA policy bulk-mixed-validation/bad-1.rego with input bulk-mixed-validation/bad-1.yaml 
✔ Action Item #1:
... snip AI output ...


✔ Action Item #2:
... snip AI output ...


ERROR Failed validation of OPA policy bulk-mixed-validation/bad-1.rego: 2 action items were returned, but 1 is required 
INFO Starting validation of OPA policy bulk-mixed-validation/good-1.rego with input bulk-mixed-validation/good-1.yaml 
... snip AI output ...

INFO Success validating OPA policy bulk-mixed-validation/good-1.rego 
INFO Starting validation of OPA policy bulk-mixed-validation/good-annotation-blocked.rego with input bulk-mixed-validation/good-annotation-blocked.yaml 
... snip AI output ...

INFO Success validating OPA policy bulk-mixed-validation/good-annotation-blocked.rego 
INFO Starting validation of OPA policy bulk-mixed-validation/missing-a-kube-manifest.rego with input bulk-mixed-validation/missing-a-kube-manifest.yaml 
ERROR Failed validation of OPA policy bulk-mixed-validation/missing-a-kube-manifest.rego: error reading Kubernetes manifest bulk-mixed-validation/missing-a-kube-manifest.yaml: open bulk-mixed-validation/missing-a-kube-manifest.yaml: no such file or directory 

OPA policies failed validation: 2 failed  and 2 succeeded
Please check the above output for details about the 2 failures: bulk-mixed-validation/bad-1.rego and bulk-mixed-validation/missing-a-kube-manifest.rego

```

### Successful Validation Output
```
$ ./cli validate opa --batch-directory bulk-success-validation
INFO Starting validation of OPA policy bulk-success-validation/1.rego with input bulk-success-validation/1.yaml 
✔ Action Item:
	Title: Forbidden Loadbalancer External IP used
	Category: Security
	Severity: 0.9
	Description: loadbalancer service has forbidden assigned IPs: {"172.19.255.200"}
	Resource Namespace: default
	Resource Kind: Service
	Resource Name: policy-test
	Remediation: Review the External IPs used and either add this IP to the allowedLBStatusIPs policy variable, or troubleshoot the Kubernetes loadbalancer provisioner
	Event Type: 1


INFO Success validating OPA policy bulk-success-validation/1.rego 
INFO Starting validation of OPA policy bulk-success-validation/annotationblocked.rego with input bulk-success-validation/annotationblocked.yaml 
✔ Action Item:
	Title: Bad annotation is present
	Category: Reliability
	Severity: 0.1
	Description: annotation {"certmanager.k8s.io/issuer"} is present
	Resource Namespace: default
	Resource Kind: Ingress
	Resource Name: policy-test
	Remediation: Remove the annotation
	Event Type: annotationblocked


INFO Success validating OPA policy bulk-success-validation/annotationblocked.rego 

OPA policies validated successfully.
```

### Failure Validation Output
```

$ ./cli validate opa --batch-directory bulk-failure-validation/
INFO Starting validation of OPA policy bulk-failure-validation/1.rego with input bulk-failure-validation/1.yaml 
✔ Action Item #1:
	Title: Forbidden External IP used
	Category: Security
	Severity: 0.9
	Description: service has forbidden external IPs: {"192.0.2.5"}
	Resource Namespace: default
	Resource Kind: Service
	Resource Name: policy-test
	Remediation: Review the External IPs used and either add this IP to the allowedServiceExternalIPs policy variable, or remove the External IP from the service
	Event Type: 1

✔ Action Item #2:
	Title: Forbidden Loadbalancer External IP used
	Category: Security
	Severity: 0.9
	Description: loadbalancer service has forbidden assigned IPs: {"172.19.255.200"}
	Resource Namespace: default
	Resource Kind: Service
	Resource Name: policy-test
	Remediation: Review the External IPs used and either add this IP to the allowedLBStatusIPs policy variable, or troubleshoot the Kubernetes loadbalancer provisioner
	Event Type: 1


ERROR Failed validation of OPA policy bulk-failure-validation/1.rego: 2 action items were returned, but 1 is required 
INFO Starting validation of OPA policy bulk-failure-validation/annotationblocked.rego with input bulk-failure-validation/annotationblocked.yaml 

ERROR Failed validation of OPA policy bulk-failure-validation/annotationblocked.rego: 0 action items were returned, but 1 is required 

OPA policies failed validation: 2 failed  and 0 succeeded
Please check the above output for details about the 2 failures: bulk-failure-validation/1.rego and bulk-failure-validation/annotationblocked.rego
```



[Internal Ticket FWI-1749](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1749)