### PR TITLE
FWI-1766 - Update Insights CLI to process .rego files other than policy as V2 OPA

### DIFF
--- a/pkg/directory/scan.go
+++ b/pkg/directory/scan.go
@@ -15,15 +15,35 @@
 package directory
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
-// ScanFolder looks through a given folder and returns all of the files found
+// ScanFolder looks through a given folder and returns a map[string][]string
+// keyed on the OPA policy name, and the value listing files providing rego
+// and V1 yaml instances for that policy.
 func ScanFolder(folder string) (map[string][]string, error) {
 	fileMap := map[string][]string{}
-	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+	regoFiles, err := getRegoFiles(folder)
+	if err != nil {
+		return nil, err
+	}
+	if len(regoFiles) > 0 {
+		logrus.Debugf("processing all top-level .rego files in %s as 2 Insights OPA policies", folder)
+		for _, rf := range regoFiles {
+			rfWithoutExt := strings.TrimSuffix(rf, filepath.Ext(rf))
+			rfWithDirectory := folder + "/" + rf
+			fileMap[rfWithoutExt] = append(fileMap[rfWithoutExt], rfWithDirectory)
+		}
+		// return fileMap, nil
+	}
+	// logrus.Debugf("treating %s as a mix of V1 and V2 Insights OPA policies as there are no top-level .rego files", folder)
+	err = filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -33,9 +53,29 @@ func ScanFolder(folder string) (map[string][]string, error) {
 		if filepath.Ext(path) != ".yaml" && !strings.HasPrefix(filepath.Base(path), "policy") {
 			return nil
 		}
+		if filepath.Dir(path) == folder { // Ignore files not in a per-policy sub-dir
+			return fmt.Errorf("File %s will not be processed because it is not in a per-policy sub-directory", path)
+		}
 		directoryName := filepath.Base(filepath.Dir(path))
 		fileMap[directoryName] = append(fileMap[directoryName], path)
 		return nil
 	})
+	logrus.Debugf("fileScan returning file-matp: %#v\n", fileMap)
 	return fileMap, err
+}
+
+// getRegoFiles returns a slice of .rego files in the specified directory.
+// This does not parse sub-directories.
+func getRegoFiles(dirName string) ([]string, error) {
+	regoFiles := make([]string, 0)
+	files, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		if strings.ToLower(filepath.Ext(file.Name())) == ".rego" {
+			regoFiles = append(regoFiles, file.Name())
+		}
+	}
+	return regoFiles, nil
 }

--- a/pkg/directory/scan.go
+++ b/pkg/directory/scan.go
@@ -15,7 +15,6 @@
 package directory
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -34,15 +33,13 @@ func ScanFolder(folder string) (map[string][]string, error) {
 		return nil, err
 	}
 	if len(regoFiles) > 0 {
-		logrus.Debugf("processing all top-level .rego files in %s as 2 Insights OPA policies", folder)
+		logrus.Debugf("processing all top-level .rego files in %s as v2 Insights OPA policies", folder)
 		for _, rf := range regoFiles {
-			rfWithoutExt := strings.TrimSuffix(rf, filepath.Ext(rf))
+			policyName := strings.TrimSuffix(rf, filepath.Ext(rf))
 			rfWithDirectory := folder + "/" + rf
-			fileMap[rfWithoutExt] = append(fileMap[rfWithoutExt], rfWithDirectory)
+			fileMap[policyName] = append(fileMap[policyName], rfWithDirectory)
 		}
-		// return fileMap, nil
 	}
-	// logrus.Debugf("treating %s as a mix of V1 and V2 Insights OPA policies as there are no top-level .rego files", folder)
 	err = filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -53,11 +50,11 @@ func ScanFolder(folder string) (map[string][]string, error) {
 		if filepath.Ext(path) != ".yaml" && !strings.HasPrefix(filepath.Base(path), "policy") {
 			return nil
 		}
-		if filepath.Dir(path) == folder { // Ignore files not in a per-policy sub-dir
-			return fmt.Errorf("File %s will not be processed because it is not in a per-policy sub-directory", path)
+		if filepath.Dir(path) == folder { // Ignore already processed top-level files
+			return nil
 		}
-		directoryName := filepath.Base(filepath.Dir(path))
-		fileMap[directoryName] = append(fileMap[directoryName], path)
+		policyName := filepath.Base(filepath.Dir(path))
+		fileMap[policyName] = append(fileMap[policyName], path)
 		return nil
 	})
 	logrus.Debugf("fileScan returning file-matp: %#v\n", fileMap)


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Process .rego files other than `policy.rego` as V2 Insights OPA policies.
### What changes did you make?
* Policies living in their own sub-directory of `opa` receive their name from the directory. THe rego must be in a file `policy.rego`. IF there are `.yaml` files the policy found in `policy.rego` is a V1 policy.
* Any .rego files in the top-level `opa` dir will be processed as V2 policies.
* Any .rego files in sub-directories NOT named `policy.rego` are processed as V2 policies and receive their name from the filename.
* A sub-directory that contains both `policy.rego` and other .rego files, will process `policy.rego` as named by the sub-directory, and additional .rego files as additional V2 policies named after the file.
* If any .rego file names (other than policy.rego) are duplicated, the CLI returns an error, as this would create an OPA Policy name conflict.
## Example Directory-structure and Output
### Duplicate V2 rego file names
This example shows output when V2 rego file names are duplicated:
```
ERRO[0000] Error scanning directory                     
FATA[0000] Unable to push OPA Checks: rego file names must be unique when not named policy.rego, please resolve these 2 duplicate files: again.rego found in [duplicates/opa/both duplicates/opa/test2] and same.rego found in [duplicates/opa duplicates/opa/test2]
```

### Processing a Mix of Rego Files
This `opa` directory structure has
* A V1 OPA Policy in both/policy.rego, with 2 instances (deployments and deployments2)
* Multiple V2 OPA policies in various directories, some named `policy.rego`, and some with other file names.
```
mixed/opa
├── 1.rego
├── 2.rego
├── both
│   ├── 5.rego
│   ├── deployments.yaml
│   ├── deployments2.yaml
│   └── policy.rego
└── test2
    ├── 3.rego
    ├── 4.rego
    └── policy.rego
```

This debug output shows how the above files are processed:
* These are .rego files treated as V2 OPA policies because they are not named `policy.rego`: `DEBU[0000] using the content of these files as V2 OPA policies: [mixed/opa/1.rego mixed/opa/2.rego mixed/opa/both/5.rego mixed/opa/test2/3.rego mixed/opa/test2/4.rego]`
* This output shows the full mapping of policy names to file names: `DEBU[0000] fileScan returning file-matp: map[string][]string{"1":[]string{"mixed/opa/1.rego"}, "2":[]string{"mixed/opa/2.rego"}, "3":[]string{"mixed/opa/test2/3.rego"}, "4":[]string{"mixed/opa/test2/4.rego"}, "5":[]string{"mixed/opa/both/5.rego"}, "both":[]string{"mixed/opa/both/deployments.yaml", "mixed/opa/both/deployments2.yaml", "mixed/opa/both/policy.rego"}, "test2":[]string{"mixed/opa/test2/policy.rego"}}`
* This output shows each policy being processed, its policy version, and the files used:
```
DEBU[0000] using content of file mixed/opa/test2/policy.rego as rego for OPA policy test2 
DEBU[0000] processed files [mixed/opa/test2/policy.rego] as v2.0 OPA policy test2 
... snip some output ...
DEBU[0000] using content of file mixed/opa/both/5.rego as rego for OPA policy 5 
DEBU[0000] processed files [mixed/opa/both/5.rego] as v2.0 OPA policy 5 
DEBU[0000] using content of file mixed/opa/both/deployments.yaml as instance for V1 OPA policy both 
DEBU[0000] using content of file mixed/opa/both/deployments2.yaml as instance for V1 OPA policy both 
DEBU[0000] using content of file mixed/opa/both/policy.rego as rego for OPA policy both 
DEBU[0000] processed files [mixed/opa/both/deployments.yaml mixed/opa/both/deployments2.yaml mixed/opa/both/policy.rego] as v1.0 OPA policy both 
```

[Internal Ticket FWI-1766](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1766)