### PR TITLE
Avoid dirting the repo for goreleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run: |
               go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
               golangci-lint run -v --timeout 2m0s
-              go test ./pkg/... -coverprofile=coverage.txt -covermode=count
+              go test ./pkg/...
       - setup_remote_docker:
           version: 20.10.11
       - *install_vault


### PR DESCRIPTION
Avoid dirtying the repository for Goreleaser by creating go test output we do not currently use.