### PR TITLE
FWI-5359 - insights-cli - make report-type required for validate rule

### DIFF
--- a/pkg/cli/validate_rule.go
+++ b/pkg/cli/validate_rule.go
@@ -20,11 +20,13 @@ func init() {
 	verifyRuleCmd.PersistentFlags().StringVarP(&insightsContext, "insights-context", "t", "", "Insights context: [AdmissionController/Agent/CI/CD]")
 	verifyRuleCmd.PersistentFlags().StringVarP(&reportType, "report-type", "R", "", "Report type: [opa, nova, kubesec, kube-hunter, kube-bench, goldilocks, admission, pluto, polaris, rbac-reporter, release-watcher, prometheus-metrics, resource-metrics, trivy, workloads, right-sizer, awscosts, falco]")
 	verifyRuleCmd.PersistentFlags().StringVarP(&expectedActionItem, "expected-action-item", "i", "", "Optional file containing the action item that the automation rule is expected to produce")
+	verifyRuleCmd.MarkPersistentFlagRequired("report-type")
+	verifyRuleCmd.MarkPersistentFlagRequired("insights-context")
 	validateCmd.AddCommand(verifyRuleCmd)
 }
 
 var verifyRuleCmd = &cobra.Command{
-	Use:    "rule -t  <insights context> {-r <rule file> -a <action item file>} [-i <expected output file>]",
+	Use:    "rule -t <insights context> -R <report type> -r <rule file> -a <action item file> [-i <expected output file>]",
 	Short:  "Validates an automation rule",
 	Long:   "Validates an automation rule by applying it against the specified action item",
 	PreRun: validateAndLoadInsightsAPIConfigWrapper,

--- a/pkg/cli/validate_rule.go
+++ b/pkg/cli/validate_rule.go
@@ -20,8 +20,14 @@ func init() {
 	verifyRuleCmd.PersistentFlags().StringVarP(&insightsContext, "insights-context", "t", "", "Insights context: [AdmissionController/Agent/CI/CD]")
 	verifyRuleCmd.PersistentFlags().StringVarP(&reportType, "report-type", "R", "", "Report type: [opa, nova, kubesec, kube-hunter, kube-bench, goldilocks, admission, pluto, polaris, rbac-reporter, release-watcher, prometheus-metrics, resource-metrics, trivy, workloads, right-sizer, awscosts, falco]")
 	verifyRuleCmd.PersistentFlags().StringVarP(&expectedActionItem, "expected-action-item", "i", "", "Optional file containing the action item that the automation rule is expected to produce")
-	verifyRuleCmd.MarkPersistentFlagRequired("report-type")
-	verifyRuleCmd.MarkPersistentFlagRequired("insights-context")
+	err := verifyRuleCmd.MarkPersistentFlagRequired("report-type")
+	if err != nil {
+		panic(err)
+	}
+	err = verifyRuleCmd.MarkPersistentFlagRequired("insights-context")
+	if err != nil {
+		panic(err)
+	}
 	validateCmd.AddCommand(verifyRuleCmd)
 }
 


### PR DESCRIPTION
This PR fixes internal FWI-5359

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- Make `report-type` and `insights-context` required to `validate rule` command

### What changes did you make?

### What alternative solution should we consider, if any?
- do not validate in the CLI and only requires at API level


[Internal Ticket FWI-5359](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-5359)