### PR TITLE
FWI-5995 - CLI - Automation Rule CLI: Print logs in CLI to help with debugging

### DIFF
--- a/pkg/cli/validate_rule.go
+++ b/pkg/cli/validate_rule.go
@@ -1,25 +1,20 @@
 package cli
 
 import (
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/fairwindsops/insights-cli/pkg/rules"
-	"github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
-var automationRuleFile, actionItemFile, expectedActionItem, reportType, insightsContext string
+var automationRuleFilePath, actionItemFilePath, expectedActionItemFilePath, reportType, insightsContext string
+var dryRun bool
 
 func init() {
-	verifyRuleCmd.PersistentFlags().StringVarP(&automationRuleFile, "automation-rule-file", "r", "./rule.js", "Automation rule JS file path")
-	verifyRuleCmd.PersistentFlags().StringVarP(&actionItemFile, "action-item-file", "a", "./action-item.yaml", "Action Item file path")
+	verifyRuleCmd.PersistentFlags().StringVarP(&automationRuleFilePath, "automation-rule-file", "r", "./rule.js", "Automation rule JS file path")
+	verifyRuleCmd.PersistentFlags().StringVarP(&actionItemFilePath, "action-item-file", "a", "./action-item.yaml", "Action Item file path")
 	verifyRuleCmd.PersistentFlags().StringVarP(&insightsContext, "insights-context", "t", "", "Insights context: [AdmissionController/Agent/CI/CD]")
 	verifyRuleCmd.PersistentFlags().StringVarP(&reportType, "report-type", "R", "", "Report type: [opa, nova, kubesec, kube-hunter, kube-bench, goldilocks, admission, pluto, polaris, rbac-reporter, release-watcher, prometheus-metrics, resource-metrics, trivy, workloads, right-sizer, awscosts, falco]")
-	verifyRuleCmd.PersistentFlags().StringVarP(&expectedActionItem, "expected-action-item", "i", "", "Optional file containing the action item that the automation rule is expected to produce")
+	verifyRuleCmd.PersistentFlags().StringVarP(&expectedActionItemFilePath, "expected-action-item", "i", "", "Optional file containing the action item that the automation rule is expected to produce")
+	verifyRuleCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "", false, "Optional flag to run the rule without executing any external integration (Slack, Jira, PagerDuty, Azure, http requests).")
 	err := verifyRuleCmd.MarkPersistentFlagRequired("report-type")
 	if err != nil {
 		panic(err)
@@ -32,72 +27,16 @@ func init() {
 }
 
 var verifyRuleCmd = &cobra.Command{
-	Use:    "rule -t <insights context> -R <report type> -r <rule file> -a <action item file> [-i <expected output file>]",
+	Use:    "rule -t <insights context> -R <report type> -r <rule file> -a <action item file> [-i <expected output file> --dry-run]",
 	Short:  "Validates an automation rule",
 	Long:   "Validates an automation rule by applying it against the specified action item",
 	PreRun: validateAndLoadInsightsAPIConfigWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
-		var actionItem rules.ActionItem
 		org := configurationObject.Options.Organization
 		host := configurationObject.Options.Hostname
-		aiInput, err := os.Open(actionItemFile)
+		err := rules.ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFilePath, expectedActionItemFilePath, reportType, insightsContext, dryRun)
 		if err != nil {
-			exitWithError(fmt.Sprintf("Error when trying to open action item file %s", actionItemFile), err)
-		}
-		aiBytes, err := io.ReadAll(aiInput)
-		if err != nil {
-			exitWithError(fmt.Sprintf("Could not read action item file %s", actionItemFile), err)
-		}
-		err = yaml.Unmarshal(aiBytes, &actionItem)
-		if err != nil {
-			exitWithError(fmt.Sprintf("Could not parse action item file %s", actionItemFile), err)
-		}
-
-		ruleInput, err := os.Open(automationRuleFile)
-		if err != nil {
-			exitWithError(fmt.Sprintf("Error when trying to open file %s", automationRuleFile), err)
-		}
-		ruleBytes, err := io.ReadAll(ruleInput)
-		if err != nil {
-			exitWithError(fmt.Sprintf("Could not read rule file %s", automationRuleFile), err)
-		}
-		verifyRule := rules.VerifyRule{
-			ActionItem: actionItem,
-			Context:    rules.RuleExecutionContext(insightsContext),
-			ReportType: reportType,
-			Script:     string(ruleBytes),
-		}
-		response, err := rules.RunVerifyRule(org, insightsToken, host, verifyRule)
-		if err != nil {
-			exitWithError("Unable to verify rule:", err)
-		}
-		b, err := yaml.Marshal(response)
-		if err != nil {
-			exitWithError("could not marshal verify result", err)
-		}
-		if expectedActionItem == "" {
-			fmt.Println(string(b))
-		} else {
-			expectedFile, err := os.Open(expectedActionItem)
-			if err != nil {
-				exitWithError(fmt.Sprintf("Error when trying to open expected file %s", expectedActionItem), err)
-			}
-			expectedContent, err := io.ReadAll(expectedFile)
-			if err != nil {
-				exitWithError("Failed to read output file", err)
-			}
-			var expectedActionItem rules.ActionItem
-			err = yaml.Unmarshal(expectedContent, &expectedActionItem)
-			if err != nil {
-				exitWithError("could not marshal expected response", err)
-			}
-			diff := cmp.Diff(&expectedActionItem, response)
-			if len(diff) == 0 {
-				logrus.Infoln("Success - actual response matches expected response")
-			} else {
-				logrus.Errorln("Test failed:")
-				fmt.Println(diff)
-			}
+			exitWithError("error validating rule", err)
 		}
 	},
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -35,7 +33,6 @@ import (
 const rulesURLFormat = "%s/v0/organizations/%s/rules"
 const rulesURLFormatCreate = "%s/v0/organizations/%s/rules/create"
 const rulesURLFormatUpdateDelete = "%s/v0/organizations/%s/rules/%d"
-const rulesURLVerify = "%s/v0/organizations/%s/rules/verify-with-events"
 
 // Rule is the struct to hold the information for a rule
 type Rule struct {
@@ -54,116 +51,6 @@ type CompareResults struct {
 	RuleInsert []Rule
 	RuleUpdate []Rule
 	RuleDelete []Rule
-}
-
-type VerifyActionItemTicketProvider string
-
-// Defines values for VerifyActionItemTicketProvider.
-const (
-	VerifyActionItemTicketProviderAzure  VerifyActionItemTicketProvider = "Azure"
-	VerifyActionItemTicketProviderGitHub VerifyActionItemTicketProvider = "GitHub"
-	VerifyActionItemTicketProviderJira   VerifyActionItemTicketProvider = "Jira"
-)
-
-type VerifyWithEvents struct {
-	ActionItem ActionItem           `json:"actionItem" yaml:"actionItem"`
-	Events     []RuleExecutionEvent `json:"events" yaml:"events"`
-}
-
-type RuleExecutionEvent struct {
-	Changelog []changelog `json:"changelog" yaml:"changelog"`
-	CreatedAt time.Time   `json:"createdAt" yaml:"createdAt"`
-	Details   string      `json:"details" yaml:"details"`
-	DryRun    bool        `json:"dryRun" yaml:"dryRun"`
-	Level     string      `json:"level" yaml:"level"`
-	Type      string      `json:"type" yaml:"type"`
-}
-
-type changelog struct {
-	From any      `json:"from" yaml:"from"`
-	Path []string `json:"path" yaml:"path"`
-	To   any      `json:"to" yaml:"to"`
-	Type string   `json:"type" yaml:"type"`
-}
-
-func (e RuleExecutionEvent) String() string {
-	const colorGreen = "\033[0;32m"
-	const colorYellow = "\033[0;33m"
-	const colorRed = "\033[0;31m"
-	const colorOrange = "\033[0;31m\033[0;33m"
-	const colorNone = "\033[0m"
-
-	var s string
-	switch e.Level {
-	case "error":
-		s = fmt.Sprintf("%s[error]%s ", colorRed, colorNone)
-	case "warn":
-		s += fmt.Sprintf("%s[warn]%s ", colorYellow, colorNone)
-	case "info":
-		s += fmt.Sprintf("%s[info]%s ", colorGreen, colorNone)
-	}
-
-	if e.DryRun {
-		s += fmt.Sprintf("%s[dry-run]%s ", colorOrange, colorNone)
-	}
-
-	switch e.Type {
-	case "edit_action_item":
-		var ss []string
-		for _, c := range e.Changelog {
-			ss = append(ss, fmt.Sprintf("%q was %q from %q to %q", c.Path[0], c.Type, c.From, c.To))
-		}
-		s += fmt.Sprintf("%q - %s - [%s]", e.Type, e.Details, strings.Join(ss, ","))
-	default:
-		s += fmt.Sprintf("%q - %s", e.Type, e.Details)
-	}
-	return s
-}
-
-type ActionItem struct {
-	TicketCreatedAt   *time.Time                      `json:"TicketCreatedAt,omitempty" yaml:"TicketCreatedAt,omitempty"`
-	TicketLink        *string                         `json:"TicketLink,omitempty" yaml:"TicketLink,omitempty"`
-	TicketProvider    *VerifyActionItemTicketProvider `json:"TicketProvider,omitempty" yaml:"TicketProvider,omitempty"`
-	AssigneeEmail     *string                         `json:"assigneeEmail,omitempty" yaml:"assigneeEmail,omitempty"`
-	Category          *string                         `json:"category,omitempty" yaml:"category,omitempty"`
-	Cluster           *string                         `json:"cluster,omitempty" yaml:"cluster,omitempty"`
-	DeletedAt         *time.Time                      `json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
-	Description       *string                         `json:"description,omitempty" yaml:"description,omitempty"`
-	EventType         *string                         `json:"eventType,omitempty" yaml:"eventType,omitempty"`
-	FirstSeen         *time.Time                      `json:"firstSeen,omitempty" yaml:"firstSeen,omitempty"`
-	Fixed             *bool                           `json:"fixed,omitempty" yaml:"fixed,omitempty"`
-	IsCustom          *bool                           `json:"isCustom,omitempty" yaml:"isCustom,omitempty"`
-	LastReportedAt    *time.Time                      `json:"lastReportedAt,omitempty" yaml:"lastReportedAt,omitempty"`
-	Notes             *string                         `json:"notes,omitempty" yaml:"notes,omitempty"`
-	Organization      *string                         `json:"organization,omitempty" yaml:"organization,omitempty"`
-	Remediation       *string                         `json:"remediation,omitempty" yaml:"remediation,omitempty"`
-	ReportType        *string                         `json:"reportType,omitempty" yaml:"reportType,omitempty"`
-	Resolution        *string                         `json:"resolution,omitempty" yaml:"resolution,omitempty"`
-	ResourceContainer *string                         `json:"resourceContainer,omitempty" yaml:"resourceContainer,omitempty"`
-	ResourceKind      *string                         `json:"resourceKind,omitempty" yaml:"resourceKind,omitempty"`
-	ResourceLabels    map[string]string               `json:"resourceLabels,omitempty" yaml:"resourceLabels,omitempty"`
-	ResourceName      *string                         `json:"resourceName,omitempty" yaml:"resourceName,omitempty"`
-	ResourceNamespace *string                         `json:"resourceNamespace,omitempty" yaml:"resourceNamespace,omitempty"`
-	Severity          *float32                        `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Tags              []string                        `json:"tags" yaml:"tags"`
-	Title             string                          `json:"title" yaml:"title"`
-}
-
-// RuleExecutionContext defines model for RuleExecutionContext.
-type RuleExecutionContext string
-
-// Defines values for RuleExecutionContext.
-const (
-	RuleExecutionContextAdmissionController RuleExecutionContext = "AdmissionController"
-	RuleExecutionContextAgent               RuleExecutionContext = "Agent"
-	RuleExecutionContextCICD                RuleExecutionContext = "CI/CD"
-)
-
-type VerifyRule struct {
-	ActionItem ActionItem           `json:"actionItem" yaml:"actionItem"`
-	Context    RuleExecutionContext `json:"context" yaml:"context"`
-	ReportType string               `json:"reportType" yaml:"reportType"`
-	Script     string               `json:"script" yaml:"script"`
 }
 
 // getRules queries Fairwinds Insights to retrieve all of the Rules for an organization
@@ -231,31 +118,6 @@ func deleteRule(org, token, hostName string, rule Rule) error {
 		return errors.New("deleteRule: invalid response code")
 	}
 	return nil
-}
-
-// RunVerifyRule verifies rule against one action item
-func RunVerifyRule(org, token, hostName string, rule VerifyRule, dryRun bool) (*VerifyWithEvents, error) {
-	url := fmt.Sprintf(rulesURLVerify, hostName, org)
-	if dryRun {
-		url += "?dryRun=true"
-	}
-
-	resp, err := req.Post(url, getRuleVerifyHeaders(token), req.BodyJSON(&rule))
-	if err != nil {
-		logrus.Errorf("error verifying rule %v in insights: %v", rule, err)
-		return nil, err
-	}
-	if resp.Response().StatusCode != http.StatusOK {
-		logrus.Errorf("runVerifyRule: invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
-		return nil, errors.New("runVerifyRule: invalid response code")
-	}
-	var verify VerifyWithEvents
-	err = resp.ToJSON(&verify)
-	if err != nil {
-		logrus.Errorf("unable to convert response to json to VerifyActionItem: %v", err)
-		return nil, err
-	}
-	return &verify, nil
 }
 
 // AddRulesBranch builds a tree for rules
@@ -439,13 +301,5 @@ func getHeaders(token string) req.Header {
 	return req.Header{
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 		"Accept":        "application/json",
-	}
-}
-
-func getRuleVerifyHeaders(token string) req.Header {
-	return req.Header{
-		"Authorization": fmt.Sprintf("Bearer %s", token),
-		"Accept":        "application/json",
-		"Content-Type":  "application/yaml",
 	}
 }

--- a/pkg/rules/validate.go
+++ b/pkg/rules/validate.go
@@ -1,14 +1,174 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/imroc/req"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
+
+const rulesURLVerify = "%s/v0/organizations/%s/rules/verify-with-events"
+
+type verifyActionItemTicketProvider string
+
+// Defines values for VerifyActionItemTicketProvider.
+const (
+	VerifyActionItemTicketProviderAzure  verifyActionItemTicketProvider = "Azure"
+	VerifyActionItemTicketProviderGitHub verifyActionItemTicketProvider = "GitHub"
+	VerifyActionItemTicketProviderJira   verifyActionItemTicketProvider = "Jira"
+)
+
+type verifyWithEvents struct {
+	ActionItem actionItem           `json:"actionItem" yaml:"actionItem"`
+	Events     []ruleExecutionEvent `json:"events" yaml:"events"`
+}
+
+type ruleExecutionEvent struct {
+	Changelog []changelog `json:"changelog" yaml:"changelog"`
+	CreatedAt time.Time   `json:"createdAt" yaml:"createdAt"`
+	Details   string      `json:"details" yaml:"details"`
+	DryRun    bool        `json:"dryRun" yaml:"dryRun"`
+	Level     string      `json:"level" yaml:"level"`
+	Type      string      `json:"type" yaml:"type"`
+}
+
+type changelog struct {
+	From any      `json:"from" yaml:"from"`
+	Path []string `json:"path" yaml:"path"`
+	To   any      `json:"to" yaml:"to"`
+	Type string   `json:"type" yaml:"type"`
+}
+
+func (e ruleExecutionEvent) String() string {
+	const colorGreen = "\033[0;32m"
+	const colorYellow = "\033[0;33m"
+	const colorRed = "\033[0;31m"
+	const colorOrange = "\033[0;31m\033[0;33m"
+	const colorNone = "\033[0m"
+
+	var s string
+	switch e.Level {
+	case "error":
+		s = fmt.Sprintf("%s[error]%s ", colorRed, colorNone)
+	case "warn":
+		s += fmt.Sprintf("%s[warn]%s ", colorYellow, colorNone)
+	case "info":
+		s += fmt.Sprintf("%s[info]%s ", colorGreen, colorNone)
+	}
+
+	if e.DryRun {
+		s += fmt.Sprintf("%s[dry-run]%s ", colorOrange, colorNone)
+	}
+
+	switch e.Type {
+	case "edit_action_item":
+		var ss []string
+		for _, c := range e.Changelog {
+			from := genericToString(c.From)
+			to := genericToString(c.To)
+
+			ss = append(ss, fmt.Sprintf("%q was %q from %q to %q", c.Path[0], c.Type, from, to))
+		}
+		s += fmt.Sprintf("%q - %s - [%s]", e.Type, e.Details, strings.Join(ss, ", "))
+	default:
+		s += fmt.Sprintf("%q - %s", e.Type, e.Details)
+	}
+	return s
+}
+
+func genericToString(i any) string {
+	switch v := i.(type) {
+	case string:
+		return v
+	case int:
+		return fmt.Sprintf("%d", v)
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case float64:
+		return fmt.Sprintf("%.2f", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+type actionItem struct {
+	TicketCreatedAt   *time.Time                      `json:"TicketCreatedAt,omitempty" yaml:"TicketCreatedAt,omitempty"`
+	TicketLink        *string                         `json:"TicketLink,omitempty" yaml:"TicketLink,omitempty"`
+	TicketProvider    *verifyActionItemTicketProvider `json:"TicketProvider,omitempty" yaml:"TicketProvider,omitempty"`
+	AssigneeEmail     *string                         `json:"assigneeEmail,omitempty" yaml:"assigneeEmail,omitempty"`
+	Category          *string                         `json:"category,omitempty" yaml:"category,omitempty"`
+	Cluster           *string                         `json:"cluster,omitempty" yaml:"cluster,omitempty"`
+	DeletedAt         *time.Time                      `json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+	Description       *string                         `json:"description,omitempty" yaml:"description,omitempty"`
+	EventType         *string                         `json:"eventType,omitempty" yaml:"eventType,omitempty"`
+	FirstSeen         *time.Time                      `json:"firstSeen,omitempty" yaml:"firstSeen,omitempty"`
+	Fixed             *bool                           `json:"fixed,omitempty" yaml:"fixed,omitempty"`
+	IsCustom          *bool                           `json:"isCustom,omitempty" yaml:"isCustom,omitempty"`
+	LastReportedAt    *time.Time                      `json:"lastReportedAt,omitempty" yaml:"lastReportedAt,omitempty"`
+	Notes             *string                         `json:"notes,omitempty" yaml:"notes,omitempty"`
+	Organization      *string                         `json:"organization,omitempty" yaml:"organization,omitempty"`
+	Remediation       *string                         `json:"remediation,omitempty" yaml:"remediation,omitempty"`
+	ReportType        *string                         `json:"reportType,omitempty" yaml:"reportType,omitempty"`
+	Resolution        *string                         `json:"resolution,omitempty" yaml:"resolution,omitempty"`
+	ResourceContainer *string                         `json:"resourceContainer,omitempty" yaml:"resourceContainer,omitempty"`
+	ResourceKind      *string                         `json:"resourceKind,omitempty" yaml:"resourceKind,omitempty"`
+	ResourceLabels    map[string]string               `json:"resourceLabels,omitempty" yaml:"resourceLabels,omitempty"`
+	ResourceName      *string                         `json:"resourceName,omitempty" yaml:"resourceName,omitempty"`
+	ResourceNamespace *string                         `json:"resourceNamespace,omitempty" yaml:"resourceNamespace,omitempty"`
+	Severity          *float32                        `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Tags              []string                        `json:"tags" yaml:"tags"`
+	Title             string                          `json:"title" yaml:"title"`
+}
+
+// ruleExecutionContext defines model for ruleExecutionContext.
+type ruleExecutionContext string
+
+// Defines values for RuleExecutionContext.
+const (
+	RuleExecutionContextAdmissionController ruleExecutionContext = "AdmissionController"
+	RuleExecutionContextAgent               ruleExecutionContext = "Agent"
+	RuleExecutionContextCICD                ruleExecutionContext = "CI/CD"
+)
+
+type verifyRule struct {
+	ActionItem actionItem           `json:"actionItem" yaml:"actionItem"`
+	Context    ruleExecutionContext `json:"context" yaml:"context"`
+	ReportType string               `json:"reportType" yaml:"reportType"`
+	Script     string               `json:"script" yaml:"script"`
+}
+
+// runVerifyRule verifies rule against one action item
+func runVerifyRule(org, token, hostName string, rule verifyRule, dryRun bool) (*verifyWithEvents, error) {
+	url := fmt.Sprintf(rulesURLVerify, hostName, org)
+	if dryRun {
+		url += "?dryRun=true"
+	}
+
+	resp, err := req.Post(url, getRuleVerifyHeaders(token), req.BodyJSON(&rule))
+	if err != nil {
+		logrus.Errorf("error verifying rule %v in insights: %v", rule, err)
+		return nil, err
+	}
+	if resp.Response().StatusCode != http.StatusOK {
+		logrus.Errorf("runVerifyRule: invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
+		return nil, errors.New("runVerifyRule: invalid response code")
+	}
+	var verify verifyWithEvents
+	err = resp.ToJSON(&verify)
+	if err != nil {
+		logrus.Errorf("unable to convert response to json to VerifyActionItem: %v", err)
+		return nil, err
+	}
+	return &verify, nil
+}
 
 func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFilePath, expectedActionItemFilePath, reportType, insightsContext string, dryRun bool) error {
 	aiInput, err := os.Open(actionItemFilePath)
@@ -21,8 +181,8 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 		return fmt.Errorf("could not read action item file %s: %v", actionItemFilePath, err)
 	}
 
-	var actionItem ActionItem
-	err = yaml.Unmarshal(aiBytes, &actionItem)
+	var ai actionItem
+	err = yaml.Unmarshal(aiBytes, &ai)
 	if err != nil {
 		return fmt.Errorf("could not parse action item file %s: %v", actionItemFilePath, err)
 	}
@@ -37,13 +197,13 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 		return fmt.Errorf("could not read rule file %s: %v", automationRuleFilePath, err)
 	}
 
-	verifyRule := VerifyRule{
-		ActionItem: actionItem,
-		Context:    RuleExecutionContext(insightsContext),
+	verifyRule := verifyRule{
+		ActionItem: ai,
+		Context:    ruleExecutionContext(insightsContext),
 		ReportType: reportType,
 		Script:     string(ruleBytes),
 	}
-	r, err := RunVerifyRule(org, insightsToken, host, verifyRule, dryRun)
+	r, err := runVerifyRule(org, insightsToken, host, verifyRule, dryRun)
 	if err != nil {
 		return fmt.Errorf("unable to verify rule: %v", err)
 	}
@@ -76,7 +236,7 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 		return fmt.Errorf("Failed to read output file: %v", err)
 	}
 
-	var expectedActionItem ActionItem
+	var expectedActionItem actionItem
 	err = yaml.Unmarshal(expectedActionItemBytes, &expectedActionItem)
 	if err != nil {
 		return fmt.Errorf("could not marshal expected response: %v", err)
@@ -89,4 +249,12 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 		fmt.Println(diff)
 	}
 	return nil
+}
+
+func getRuleVerifyHeaders(token string) req.Header {
+	return req.Header{
+		"Authorization": fmt.Sprintf("Bearer %s", token),
+		"Accept":        "application/json",
+		"Content-Type":  "application/yaml",
+	}
 }

--- a/pkg/rules/validate.go
+++ b/pkg/rules/validate.go
@@ -239,7 +239,7 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 	if err != nil {
 		return fmt.Errorf("could not marshal expected response: %v", err)
 	}
-	diff := cmp.Diff(&expectedActionItem, responseActionItem)
+	diff := cmp.Diff(expectedActionItem, responseActionItem)
 	if len(diff) == 0 {
 		logrus.Infoln("Success - actual response matches expected response")
 	} else {

--- a/pkg/rules/validate.go
+++ b/pkg/rules/validate.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -154,18 +153,17 @@ func runVerifyRule(org, token, hostName string, rule verifyRule, dryRun bool) (*
 
 	resp, err := req.Post(url, getRuleVerifyHeaders(token), req.BodyJSON(&rule))
 	if err != nil {
-		logrus.Errorf("error verifying rule %v in insights: %v", rule, err)
-		return nil, err
+		return nil, fmt.Errorf("error verifying rule in Insights: %v", err)
+
 	}
 	if resp.Response().StatusCode != http.StatusOK {
-		logrus.Errorf("runVerifyRule: invalid response code: %s %v", string(resp.Bytes()), resp.Response().StatusCode)
-		return nil, errors.New("runVerifyRule: invalid response code")
+		return nil, fmt.Errorf("invalid response code: %v - %s", resp.Response().StatusCode, string(resp.Bytes()))
 	}
 	var verify verifyWithEvents
 	err = resp.ToJSON(&verify)
 	if err != nil {
-		logrus.Errorf("unable to convert response to json to VerifyActionItem: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("unable to convert response to json: %v", err)
+
 	}
 	return &verify, nil
 }
@@ -228,12 +226,12 @@ func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFi
 
 	expectedActionItemFile, err := os.Open(expectedActionItemFilePath)
 	if err != nil {
-		return fmt.Errorf("Error when trying to open expected file %s: %v", expectedActionItemFilePath, err)
+		return fmt.Errorf("error when trying to open expected file %s: %v", expectedActionItemFilePath, err)
 	}
 
 	expectedActionItemBytes, err := io.ReadAll(expectedActionItemFile)
 	if err != nil {
-		return fmt.Errorf("Failed to read output file: %v", err)
+		return fmt.Errorf("failed to read output file: %v", err)
 	}
 
 	var expectedActionItem actionItem

--- a/pkg/rules/validate.go
+++ b/pkg/rules/validate.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+func ValidateRule(org, host, insightsToken, automationRuleFilePath, actionItemFilePath, expectedActionItemFilePath, reportType, insightsContext string, dryRun bool) error {
+	aiInput, err := os.Open(actionItemFilePath)
+	if err != nil {
+		return fmt.Errorf("error when trying to open action item file %s: %v", actionItemFilePath, err)
+	}
+
+	aiBytes, err := io.ReadAll(aiInput)
+	if err != nil {
+		return fmt.Errorf("could not read action item file %s: %v", actionItemFilePath, err)
+	}
+
+	var actionItem ActionItem
+	err = yaml.Unmarshal(aiBytes, &actionItem)
+	if err != nil {
+		return fmt.Errorf("could not parse action item file %s: %v", actionItemFilePath, err)
+	}
+
+	ruleInput, err := os.Open(automationRuleFilePath)
+	if err != nil {
+		return fmt.Errorf("error when trying to open file %s: %v", automationRuleFilePath, err)
+	}
+
+	ruleBytes, err := io.ReadAll(ruleInput)
+	if err != nil {
+		return fmt.Errorf("could not read rule file %s: %v", automationRuleFilePath, err)
+	}
+
+	verifyRule := VerifyRule{
+		ActionItem: actionItem,
+		Context:    RuleExecutionContext(insightsContext),
+		ReportType: reportType,
+		Script:     string(ruleBytes),
+	}
+	r, err := RunVerifyRule(org, insightsToken, host, verifyRule, dryRun)
+	if err != nil {
+		return fmt.Errorf("unable to verify rule: %v", err)
+	}
+	responseActionItem := r.ActionItem
+
+	if len(r.Events) > 0 {
+		fmt.Printf("\n-- Logs --\n\n")
+		for _, e := range r.Events {
+			fmt.Println(e)
+		}
+	}
+
+	if expectedActionItemFilePath == "" {
+		fmt.Printf("\n-- Returned Action Item --\n\n")
+		b, err := yaml.Marshal(responseActionItem)
+		if err != nil {
+			return fmt.Errorf("could not marshal verify result: %v", err)
+		}
+		fmt.Println(string(b))
+		return nil
+	}
+
+	expectedActionItemFile, err := os.Open(expectedActionItemFilePath)
+	if err != nil {
+		return fmt.Errorf("Error when trying to open expected file %s: %v", expectedActionItemFilePath, err)
+	}
+
+	expectedActionItemBytes, err := io.ReadAll(expectedActionItemFile)
+	if err != nil {
+		return fmt.Errorf("Failed to read output file: %v", err)
+	}
+
+	var expectedActionItem ActionItem
+	err = yaml.Unmarshal(expectedActionItemBytes, &expectedActionItem)
+	if err != nil {
+		return fmt.Errorf("could not marshal expected response: %v", err)
+	}
+	diff := cmp.Diff(&expectedActionItem, responseActionItem)
+	if len(diff) == 0 {
+		logrus.Infoln("Success - actual response matches expected response")
+	} else {
+		logrus.Errorln("Test failed:")
+		fmt.Println(diff)
+	}
+	return nil
+}

--- a/testdata/scripts/push_all_and_list.txtar
+++ b/testdata/scripts/push_all_and_list.txtar
@@ -120,7 +120,7 @@ spec:
            deployments
        v2test (v2)
    rules
-       pluto severity increase
+       pluto-severity-increase
    app-groups
        all
    policy-mappings

--- a/testdata/scripts/push_all_and_list.txtar
+++ b/testdata/scripts/push_all_and_list.txtar
@@ -89,7 +89,7 @@ targets:
 
 # An automation rule.
 -- populated_dir/rules/pluto-severity.yaml --
-name: "pluto severity increase"
+name: "pluto-severity-increase"
 description: "Assigns all Action Items from pluto to a higher severity@"
 action: |
   if (ActionItem.ReportType === 'pluto') {


### PR DESCRIPTION
This PR fixes #
- adds `dry-run` support to `validate rule` command
- output rule execution logs  

Requires https://github.com/FairwindsOps/Insights/pull/4645 to be released

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?



[Internal Ticket FWI-5995](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-5995)