### PR TITLE
Update release command to skip signing for snapshot builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     resource_class: large
     docker:
       # Note the goreleaser version is also referenced in the release and snapshot jobs.
-      - image: goreleaser/goreleaser:v2.14.2
+      - image: goreleaser/goreleaser:v2.15.4
     steps:
       - checkout
       - run:
@@ -75,7 +75,7 @@ jobs:
               -v /var/run/docker.sock:/var/run/docker.sock \
               -v "$(pwd):/workspace" -w /workspace \
               -e CIRCLE_SHA1 -e CIRCLE_BRANCH -e CIRCLE_TAG \
-              goreleaser/goreleaser:v2.14.2 release --snapshot
+              goreleaser/goreleaser:v2.15.4 release --snapshot --skip=sign
       - run: mkdir snapshot-artifacts && cp dist/*.tar.gz dist/*.txt dist/*.json snapshot-artifacts
       - store_artifacts:
           path: snapshot-artifacts
@@ -112,7 +112,7 @@ jobs:
               -e GORELEASER_CURRENT_TAG -e CIRCLE_TAG -e CIRCLE_SHA1 \
               -e GO111MODULE=on \
               -e GITHUB_TOKEN \
-              goreleaser/goreleaser:v2.14.2 release
+              goreleaser/goreleaser:v2.15.4 release
       - run:
           name: docker login Google Artifact Registry
           command: |


### PR DESCRIPTION
And Bump goreleaser version to v2.15.4

This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

